### PR TITLE
[Add #20] add basic bytecode interpreter loop

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -34,4 +34,16 @@ impl CPU {
             program_counter: 0,
         }
     }
+    pub fn interpret(&mut self, program: Vec<u8>) {
+        self.program_counter = 0;
+
+        loop {
+            let opscode = program[self.program_counter as usize];
+            self.program_counter += 1;
+
+            match opscode {
+                _ => todo!(),
+            }
+        }
+    }
 }


### PR DESCRIPTION
interpret`関数は与えられたプログラムのバイトコードをループで処理し、各オプコードを処理するために `match` ステートメントを使用する。実際のオペコード固有のロジックはまだ実装されておらず、プレースホルダ（`todo!このコミットの目的は、バイトコード命令を解釈するための基礎を確立することであり、将来のコミットでオペコードの実装を拡張することです。

