### PR TITLE
[Test #5] Integration of prev implemented opcodes

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -183,4 +183,12 @@ mod tests {
         cpu.interpret(vec![0xe8, 0x00]);
         assert!(cpu.status.negative_flag == true);
     }
+
+    #[test]
+    fn test_5_ops_working_together() {
+        let mut cpu = CPU::new();
+        cpu.interpret(vec![0xa9, 0xc0, 0xaa, 0xe8, 0x00]);
+
+        assert_eq!(cpu.index_register_x, 0xc1)
+    }
 }


### PR DESCRIPTION
既存のオペコードの統合

先行して実装したオペコードの連携を確認するための包括的なテスト test_5_ops_working_together を追加しました。
CPUのインスタンスを作成し、オペコードのシーケンス（LDA、TAX、INX、BRK）を実行し、予想される結果を検証しました。
このテストにより、CPUの機能が正しく統合されており、インデックスレジスタXが予想通りに変更されていることが確認できます。