### PR TITLE
Issue/read#32

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -53,6 +53,12 @@ impl CPU {
         self.memory[addr as usize]
     }
 
+    fn mem_read_u16(&mut self, pos: u16) -> u16 {
+        let lo = self.mem_read(pos) as u16;
+        let hi = self.mem_read(pos + 1) as u16;
+        (hi << 8) | (lo as u16)
+    }
+
     fn mem_write(&mut self, addr: u16, data: u8) {
         self.memory[addr as usize] = data
     }
@@ -61,6 +67,8 @@ impl CPU {
         self.accumulator = 0;
         self.index_register_x = 0;
         self.status = ProcessorStatus::clear();
+
+        self.program_counter = self.mem_read_u16(0xfffc);
     }
 
     pub fn load(&mut self, program: Vec<u8>) {

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -63,6 +63,13 @@ impl CPU {
         self.memory[addr as usize] = data
     }
 
+    fn mem_write_u16(&mut self, pos: u16, data: u16) {
+        let hi = (data >> 8) as u8;
+        let lo = (data & 0xff) as u8;
+        self.mem_write(pos, lo);
+        self.mem_write(pos + 1, hi);
+    }
+
     pub fn reset(&mut self) {
         self.accumulator = 0;
         self.index_register_x = 0;
@@ -73,7 +80,7 @@ impl CPU {
 
     pub fn load(&mut self, program: Vec<u8>) {
         self.memory[0x8000..(0x8000 + program.len())].copy_from_slice(&program[..]);
-        self.program_counter = 0x8000
+        self.mem_write_u16(0xfffc, 0x8000);
     }
 
     fn lda(&mut self, value: u8) {
@@ -246,6 +253,14 @@ mod tests {
     }
 
     #[test]
+    fn test_mem_read_write_u16() {
+        let mut cpu = CPU::new();
+        cpu.mem_write_u16(0x8000, 0xABCD);
+        let value = cpu.mem_read_u16(0x8000);
+        assert_eq!(value, 0xABCD)
+    }
+
+    #[test]
     fn test_load() {
         let mut cpu = CPU::new();
         let program: Vec<u8> = vec![0x01, 0x02, 0x03];
@@ -260,7 +275,7 @@ mod tests {
             );
             assert_eq!(cpu.memory[memory_index], byte);
         }
-        assert_eq!(cpu.program_counter, 0x8000);
+        assert_eq!(cpu.program_counter, 0);
     }
 
     #[test]


### PR DESCRIPTION
16ビットメモリー操作機能の実装、16ビットメモリー操作機能の実装に伴った
リセット機能、ロード機能の一部実装変更を導入する。

変更点
- 16 ビット・メモリの読み込み操作を行うための `mem_read_u16` メソッドを追加。
- 16 ビットメモリの書き込み操作を行う `mem_write_u16` メソッドを追加。
- メモリから読み出されたリセット・ベクタを使用してプログラム・カウンタを設定するように`reset`メソッドを変更しました。
- ロードアドレス（0x8000）をメモリのリセットベクタに書き込むように`load`メソッドを変更。

テスト：
- mem_read_u16` と `mem_write_u16` のユニットテストを追加した。

#32,#33