### PR TITLE
Issue/Addresing_mode#44

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -35,6 +35,7 @@ pub enum AddressingMode {
     Indirect,
     Indirect_X,
     Indirect_Y,
+    NoneAddressing,
 }
 
 pub struct CPU {
@@ -124,6 +125,7 @@ impl CPU {
                 deref_addr
             }
 
+            AddressingMode::NoneAddressing => panic!("mode {:?} is not supported", mode),
         }
     }
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -30,6 +30,7 @@ pub enum AddressingMode {
     ZeroPage_X,
     ZeroPage_Y,
     Absolute,
+    Absolute_X,
 }
 
 pub struct CPU {
@@ -80,6 +81,12 @@ impl CPU {
             }
 
             AddressingMode::Absolute => self.mem_read_u16(self.program_counter),
+
+            AddressingMode::Absolute_X => {
+                let pos = self.mem_read_u16(self.program_counter);
+                let addr = pos.wrapping_add(self.index_register_x as u16);
+                addr
+            }
 
         }
     }
@@ -377,6 +384,17 @@ mod tests {
         let mode = AddressingMode::Absolute;
         let result = cpu.get_operand_address(&mode);
         assert_eq!(result, 0x4980);
+    }
+
+    #[test]
+    fn test_get_operand_address_absolute_x() {
+        let mut cpu = CPU::new();
+        cpu.index_register_x = 0x20;
+        cpu.memory[cpu.program_counter as usize] = 0x30;
+        cpu.memory[cpu.program_counter.wrapping_add(1) as usize] = 0x98;
+        let mode = AddressingMode::Absolute_X;
+        let result = cpu.get_operand_address(&mode);
+        assert_eq!(result, 0x9850);
     }
 
 }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -29,6 +29,7 @@ pub enum AddressingMode {
     ZeroPage,
     ZeroPage_X,
     ZeroPage_Y,
+    Absolute,
 }
 
 pub struct CPU {
@@ -77,6 +78,9 @@ impl CPU {
                 let addr = pos.wrapping_add(self.index_register_y) as u16;
                 addr
             }
+
+            AddressingMode::Absolute => self.mem_read_u16(self.program_counter),
+
         }
     }
 
@@ -365,4 +369,14 @@ mod tests {
         let result = cpu.get_operand_address(&mode);
         assert_eq!(result, 0x52);
     }
+    #[test]
+    fn test_get_operand_address_absolute() {
+        let mut cpu = CPU::new();
+        cpu.memory[cpu.program_counter as usize] = 0x80;
+        cpu.memory[cpu.program_counter.wrapping_add(1) as usize] = 0x49;
+        let mode = AddressingMode::Absolute;
+        let result = cpu.get_operand_address(&mode);
+        assert_eq!(result, 0x4980);
+    }
+
 }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -36,6 +36,7 @@ pub enum AddressingMode {
     Indirect_X,
     Indirect_Y,
     NoneAddressing,
+    Relative,
 }
 
 pub struct CPU {
@@ -123,6 +124,13 @@ impl CPU {
                 let deref_base = (hi as u16) << 8 | (lo as u16);
                 let deref_addr = deref_base.wrapping_add(self.index_register_y as u16);
                 deref_addr
+            }
+
+            AddressingMode::Relative => {
+                let base = self.mem_read(self.program_counter) as i8;
+                let addr = (self.program_counter as i16).wrapping_add(base as i16) as u16;
+
+                addr
             }
 
             AddressingMode::NoneAddressing => panic!("mode {:?} is not supported", mode),
@@ -480,5 +488,14 @@ mod tests {
         let mode = AddressingMode::Indirect_Y;
         let result = cpu.get_operand_address(&mode);
         assert_eq!(result, 0xB255);
+    }
+
+    #[test]
+    fn test_get_operand_address_relative() {
+        let mut cpu = CPU::new();
+        cpu.memory[cpu.program_counter as usize] = 0x60;
+        let mode = AddressingMode::Relative;
+        let result = cpu.get_operand_address(&mode);
+        assert_eq!(result, 0x60)
     }
 }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -26,6 +26,7 @@ impl ProcessorStatus {
 #[allow(non_camel_case_types)]
 pub enum AddressingMode {
     Immediate,
+    ZeroPage,
 }
 
 pub struct CPU {
@@ -58,6 +59,8 @@ impl CPU {
     fn get_operand_address(&self, mode: &AddressingMode) -> u16 {
         match mode {
             AddressingMode::Immediate => self.program_counter,
+
+            AddressingMode::ZeroPage => self.mem_read(self.program_counter) as u16,
 
         }
     }
@@ -318,4 +321,12 @@ mod tests {
         assert_eq!(result, cpu.program_counter);
     }
 
+    #[test]
+    fn test_get_operand_address_zero_page() {
+        let mut cpu = CPU::new();
+        cpu.memory[cpu.program_counter as usize] = 0x44;
+        let mode = AddressingMode::ZeroPage;
+        let result = cpu.get_operand_address(&mode);
+        assert_eq!(result, 0x44);
+    }
 }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -27,6 +27,7 @@ impl ProcessorStatus {
 pub enum AddressingMode {
     Immediate,
     ZeroPage,
+    ZeroPage_X,
 }
 
 pub struct CPU {
@@ -61,6 +62,12 @@ impl CPU {
             AddressingMode::Immediate => self.program_counter,
 
             AddressingMode::ZeroPage => self.mem_read(self.program_counter) as u16,
+
+            AddressingMode::ZeroPage_X => {
+                let pos = self.mem_read(self.program_counter);
+                let addr = pos.wrapping_add(self.index_register_x) as u16;
+                addr
+            }
 
         }
     }
@@ -329,4 +336,15 @@ mod tests {
         let result = cpu.get_operand_address(&mode);
         assert_eq!(result, 0x44);
     }
+
+    #[test]
+    fn test_get_operand_address_zero_page_x() {
+        let mut cpu = CPU::new();
+        cpu.index_register_x = 0x10;
+        cpu.memory[cpu.program_counter as usize] = 0x44;
+        let mode = AddressingMode::ZeroPage_X;
+        let result = cpu.get_operand_address(&mode);
+        assert_eq!(result, 0x54);
+    }
+
 }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -35,6 +35,7 @@ pub struct CPU {
     pub status: ProcessorStatus,
     pub program_counter: u16,
     pub index_register_x: u8,
+    pub index_register_y: u8,
     memory: [u8; 0x10000],
 }
 
@@ -53,6 +54,7 @@ impl CPU {
             },
             program_counter: 0,
             index_register_x: 0,
+            index_register_y: 0,
             memory: [0; 0x10000],
         }
     }
@@ -96,6 +98,7 @@ impl CPU {
     pub fn reset(&mut self) {
         self.accumulator = 0;
         self.index_register_x = 0;
+        self.index_register_y = 0;
         self.status = ProcessorStatus::clear();
 
         self.program_counter = self.mem_read_u16(0xfffc);

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -22,6 +22,12 @@ impl ProcessorStatus {
     }
 }
 
+#[derive(Debug)]
+#[allow(non_camel_case_types)]
+pub enum AddressingMode {
+    Immediate,
+}
+
 pub struct CPU {
     pub accumulator: u8,
     pub status: ProcessorStatus,
@@ -46,6 +52,13 @@ impl CPU {
             program_counter: 0,
             index_register_x: 0,
             memory: [0; 0x10000],
+        }
+    }
+
+    fn get_operand_address(&self, mode: &AddressingMode) -> u16 {
+        match mode {
+            AddressingMode::Immediate => self.program_counter,
+
         }
     }
 
@@ -296,4 +309,13 @@ mod tests {
         assert_eq!(cpu.index_register_x, 0,);
         assert_eq!(cpu.status.negative_flag, false);
     }
+
+    #[test]
+    fn test_get_operand_address_immediate() {
+        let cpu = CPU::new();
+        let mode = AddressingMode::Immediate;
+        let result = cpu.get_operand_address(&mode);
+        assert_eq!(result, cpu.program_counter);
+    }
+
 }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -31,6 +31,7 @@ pub enum AddressingMode {
     ZeroPage_Y,
     Absolute,
     Absolute_X,
+    Absolute_Y,
 }
 
 pub struct CPU {
@@ -85,6 +86,12 @@ impl CPU {
             AddressingMode::Absolute_X => {
                 let pos = self.mem_read_u16(self.program_counter);
                 let addr = pos.wrapping_add(self.index_register_x as u16);
+                addr
+            }
+
+            AddressingMode::Absolute_Y => {
+                let pos = self.mem_read_u16(self.program_counter);
+                let addr = pos.wrapping_add(self.index_register_y as u16);
                 addr
             }
 
@@ -397,4 +404,14 @@ mod tests {
         assert_eq!(result, 0x9850);
     }
 
+    #[test]
+    fn test_get_operand_address_absolute_y() {
+        let mut cpu = CPU::new();
+        cpu.index_register_y = 0x42;
+        cpu.memory[cpu.program_counter as usize] = 0x90;
+        cpu.memory[cpu.program_counter.wrapping_add(1) as usize] = 0xE0;
+        let mode = AddressingMode::Absolute_Y;
+        let result = cpu.get_operand_address(&mode);
+        assert_eq!(result, 0xE0D2);
+    }
 }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -28,6 +28,7 @@ pub enum AddressingMode {
     Immediate,
     ZeroPage,
     ZeroPage_X,
+    ZeroPage_Y,
 }
 
 pub struct CPU {
@@ -71,6 +72,11 @@ impl CPU {
                 addr
             }
 
+            AddressingMode::ZeroPage_Y => {
+                let pos = self.mem_read(self.program_counter);
+                let addr = pos.wrapping_add(self.index_register_y) as u16;
+                addr
+            }
         }
     }
 
@@ -350,4 +356,13 @@ mod tests {
         assert_eq!(result, 0x54);
     }
 
+    #[test]
+    fn test_get_operand_address_zero_page_y() {
+        let mut cpu = CPU::new();
+        cpu.index_register_y = 0x02;
+        cpu.memory[cpu.program_counter as usize] = 0x50;
+        let mode = AddressingMode::ZeroPage_Y;
+        let result = cpu.get_operand_address(&mode);
+        assert_eq!(result, 0x52);
+    }
 }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -69,7 +69,7 @@ impl CPU {
         self.memory[addr as usize]
     }
 
-    fn mem_read_u16(&mut self, pos: u16) -> u16 {
+    fn mem_read_u16(&self, pos: u16) -> u16 {
         let lo = self.mem_read(pos) as u16;
         let hi = self.mem_read(pos + 1) as u16;
         (hi << 8) | (lo as u16)

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -37,6 +37,7 @@ pub enum AddressingMode {
     Indirect_Y,
     NoneAddressing,
     Relative,
+    Accumulator,
 }
 
 pub struct CPU {
@@ -132,6 +133,8 @@ impl CPU {
 
                 addr
             }
+
+            AddressingMode::Accumulator => self.accumulator as u16,
 
             AddressingMode::NoneAddressing => panic!("mode {:?} is not supported", mode),
         }
@@ -497,5 +500,14 @@ mod tests {
         let mode = AddressingMode::Relative;
         let result = cpu.get_operand_address(&mode);
         assert_eq!(result, 0x60)
+    }
+
+    #[test]
+    fn test_get_operand_address_accumulator() {
+        let mut cpu = CPU::new();
+        cpu.accumulator = 0x42;
+        let mode = AddressingMode::Accumulator;
+        let result = cpu.get_operand_address(&mode);
+        assert_eq!(result, 0x42);
     }
 }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -34,6 +34,7 @@ pub enum AddressingMode {
     Absolute_Y,
     Indirect,
     Indirect_X,
+    Indirect_Y,
 }
 
 pub struct CPU {
@@ -112,6 +113,15 @@ impl CPU {
                 let hi = self.mem_read(ptr.wrapping_add(1) as u16);
                 let addr = (hi as u16) << 8 | (lo as u16);
                 addr
+            }
+
+            AddressingMode::Indirect_Y => {
+                let base = self.mem_read(self.program_counter);
+                let lo = self.mem_read(base as u16);
+                let hi = self.mem_read((base).wrapping_add(1) as u16);
+                let deref_base = (hi as u16) << 8 | (lo as u16);
+                let deref_addr = deref_base.wrapping_add(self.index_register_y as u16);
+                deref_addr
             }
 
         }
@@ -457,5 +467,16 @@ mod tests {
         let mode = AddressingMode::Indirect_X;
         let result = cpu.get_operand_address(&mode);
         assert_eq!(result, 0x0910);
+    }
+    #[test]
+    fn test_get_operand_address_indirect_y() {
+        let mut cpu = CPU::new();
+        cpu.memory[cpu.program_counter as usize] = 0xA0;
+        cpu.memory[0xA0] = 0x50;
+        cpu.memory[0xA1] = 0xB2;
+        cpu.index_register_y = 0x05;
+        let mode = AddressingMode::Indirect_Y;
+        let result = cpu.get_operand_address(&mode);
+        assert_eq!(result, 0xB255);
     }
 }


### PR DESCRIPTION
get_operand_address関数のさまざまなアドレッシングモードに対するオペランドアドレス計算を改善しています。また、関連するテストケースを更新して正確性を確保しています。

変更内容:
- オペランドアドレス計算の実装を、サポートされているすべてのアドレッシングモードに対して簡素化しました。
- 既存のテストケースを変更後のオペランドアドレス計算ロジックを検証できるように調整しました。

Closes
#44,#48,#49,#32,#50,#51,#52,#53,#54,#55,#56,#57,#58,#61,#62,#63

