### PR TITLE
Issue/Add_test_code_for_each_addressing_mode#74

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -220,7 +220,6 @@ impl CPU {
 
     pub fn run(&mut self) {
         let ref opcodes = *opcodes::OPCODES_MAP;
-        // let ref opcodes: HashMap<u8, &'static opcodes::OpCode> = *opcodes::OPCODES_MAP;
 
         loop {
             let code = self.mem_read(self.program_counter);
@@ -254,375 +253,352 @@ impl CPU {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_0x00_brk() {
-        let mut cpu = CPU::new();
-        cpu.load_and_run(vec![0x00]);
-        assert_eq!(
-            cpu.program_counter, 0x8001,
-            "オペコードBRKが実行された際のプログラムカウンタが正しくありません"
-        );
-    }
+    mod opcode_tests {
+        use super::*;
 
-    #[test]
-    fn test_0x9a_lda_load_immediate_load_data() {
-        let mut cpu = CPU::new();
-        cpu.load_and_run(vec![0xa9, 0x05, 0x00]);
+        mod lda {
+            use super::*;
 
-        assert_eq!(cpu.accumulator, 0x05);
-        assert!(cpu.status.zero_flag == false);
-        assert!(cpu.status.negative_flag == false);
-    }
-    #[test]
-    fn test_lda_from_memory() {
-        let mut cpu = CPU::new();
-        cpu.mem_write(0x10, 0x55);
-        cpu.load_and_run(vec![0xA5, 0x10, 0x00]);
-        assert_eq!(cpu.accumulator, 0x55);
-    }
+            #[test]
+            fn test_lda_effects() {
+                let mut cpu = CPU::new();
 
-    #[test]
-    fn test_lda_immediate() {
-        let mut cpu = CPU::new();
-        cpu.load_and_run(vec![0xA9, 0x10, 0x00]);
-        assert_eq!(cpu.accumulator, 0x10);
-    }
+                cpu.load_and_run(vec![0xa9, 0x05, 0x00]);
 
-    #[test]
-    fn test_lda_zero_page() {
-        let mut cpu = CPU::new();
-        cpu.mem_write(0x10, 0x78);
-        cpu.load_and_run(vec![0xA5, 0x10, 0x00]);
-        assert_eq!(cpu.accumulator, 0x78);
-    }
+                assert_eq!(cpu.accumulator, 0x05);
+                assert!(cpu.status.zero_flag == false);
+                assert!(cpu.status.negative_flag == false);
 
-    #[test]
-    fn test_lda_zero_page_x() {
-        let mut cpu = CPU::new();
-        cpu.mem_write(0x28, 0x07);
-        cpu.load(vec![0xB5, 0x08, 0x00]);
-        cpu.reset();
-        cpu.index_register_x = 0x20;
-        cpu.run();
-        assert_eq!(cpu.accumulator, 0x07);
-    }
+                cpu.load_and_run(vec![0xa9, 0x00, 0x00]);
+                assert!(cpu.status.zero_flag == true);
 
-    #[test]
-    fn test_lda_absolute() {
-        let mut cpu = CPU::new();
-        cpu.mem_write(0x5228, 0xF0);
-        cpu.load_and_run(vec![0xAD, 0x28, 0x52, 0x00]);
-        assert_eq!(cpu.accumulator, 0xF0);
-    }
+                cpu.load_and_run(vec![0xa9, 0x80, 0x00]);
+                assert!(cpu.status.negative_flag == true);
+            }
 
-    #[test]
-    fn test_lda_absolute_x() {
-        let mut cpu = CPU::new();
-        cpu.mem_write(0xF0B9, 0x98);
-        cpu.load(vec![0xBD, 0xA8, 0xF0, 0x00]);
-        cpu.reset();
-        cpu.index_register_x = 0x11;
-        cpu.run();
-        assert_eq!(cpu.accumulator, 0x98);
-    }
+            #[test]
+            fn test_lda_immediate() {
+                let mut cpu = CPU::new();
+                cpu.load_and_run(vec![0xA9, 0x10, 0x00]);
+                assert_eq!(cpu.accumulator, 0x10);
+            }
 
-    #[test]
-    fn test_lda_absolute_y() {
-        let mut cpu = CPU::new();
-        cpu.mem_write(0x5A00, 0xEA);
-        cpu.load(vec![0xB9, 0xB0, 0x59, 0x00]);
-        cpu.reset();
-        cpu.index_register_y = 0x50;
-        cpu.run();
-        assert_eq!(cpu.accumulator, 0xEA);
-    }
+            #[test]
+            fn test_lda_zero_page() {
+                let mut cpu = CPU::new();
+                cpu.mem_write(0x10, 0x78);
+                cpu.load_and_run(vec![0xA5, 0x10, 0x00]);
+                assert_eq!(cpu.accumulator, 0x78);
+            }
 
-    #[test]
-    fn test_lda_indirect_x() {
-        let mut cpu = CPU::new();
-        cpu.mem_write_u16(0x85, 0x2030);
-        cpu.mem_write(0x2030, 0xE1);
-        cpu.load(vec![0xA1, 0x80, 0x00]);
-        cpu.reset();
-        cpu.index_register_x = 0x05;
-        cpu.run();
-        assert_eq!(cpu.accumulator, 0xE1);
-    }
+            #[test]
+            fn test_lda_zero_page_x() {
+                let mut cpu = CPU::new();
+                cpu.mem_write(0x28, 0x07);
+                cpu.load(vec![0xB5, 0x08, 0x00]);
+                cpu.reset();
+                cpu.index_register_x = 0x20;
+                cpu.run();
+                assert_eq!(cpu.accumulator, 0x07);
+            }
 
-    #[test]
-    fn test_lda_indirect_y() {
-        let mut cpu = CPU::new();
-        cpu.mem_write_u16(0x80, 0x2030);
-        cpu.mem_write(0x2035, 0xE6);
-        cpu.load(vec![0xB1, 0x80, 0x00]);
-        cpu.reset();
-        cpu.index_register_y = 0x05;
-        cpu.run();
-        assert_eq!(cpu.accumulator, 0xE6);
-    }
+            #[test]
+            fn test_lda_absolute() {
+                let mut cpu = CPU::new();
+                cpu.mem_write(0x5228, 0xF0);
+                cpu.load_and_run(vec![0xAD, 0x28, 0x52, 0x00]);
+                assert_eq!(cpu.accumulator, 0xF0);
+            }
 
-    #[test]
-    fn test_0xa9_lda_zero_flag() {
-        let mut cpu = CPU::new();
-        cpu.load_and_run(vec![0xa9, 0x00, 0x00]);
+            #[test]
+            fn test_lda_absolute_x() {
+                let mut cpu = CPU::new();
+                cpu.mem_write(0xF0B9, 0x98);
+                cpu.load(vec![0xBD, 0xA8, 0xF0, 0x00]);
+                cpu.reset();
+                cpu.index_register_x = 0x11;
+                cpu.run();
+                assert_eq!(cpu.accumulator, 0x98);
+            }
 
-        assert!(cpu.status.zero_flag == true);
-    }
+            #[test]
+            fn test_lda_absolute_y() {
+                let mut cpu = CPU::new();
+                cpu.mem_write(0x5A00, 0xEA);
+                cpu.load(vec![0xB9, 0xB0, 0x59, 0x00]);
+                cpu.reset();
+                cpu.index_register_y = 0x50;
+                cpu.run();
+                assert_eq!(cpu.accumulator, 0xEA);
+            }
 
-    #[test]
-    fn test_0xa9_lda_negative_flag() {
-        let mut cpu = CPU::new();
-        cpu.load_and_run(vec![0xa9, 0x80, 0x00]);
+            #[test]
+            fn test_lda_indirect_x() {
+                let mut cpu = CPU::new();
+                cpu.mem_write_u16(0x85, 0x2030);
+                cpu.mem_write(0x2030, 0xE1);
+                cpu.load(vec![0xA1, 0x80, 0x00]);
+                cpu.reset();
+                cpu.index_register_x = 0x05;
+                cpu.run();
+                assert_eq!(cpu.accumulator, 0xE1);
+            }
 
-        assert!(cpu.status.negative_flag == true);
-    }
-
-    #[test]
-    fn test_0xaa_tax_move_a_to_x() {
-        let mut cpu = CPU::new();
-        cpu.load_and_run(vec![0xa9, 0x10, 0xaa, 0x00]);
-
-        assert_eq!(cpu.index_register_x, 16);
-        assert!(cpu.status.zero_flag == false);
-        assert!(cpu.status.negative_flag == false);
-    }
-
-    #[test]
-    fn test_0xaa_tax_zero_flag() {
-        let mut cpu = CPU::new();
-        cpu.load_and_run(vec![0xa9, 0x00, 0xaa, 0x00]);
-
-        assert!(cpu.status.zero_flag == true);
-    }
-
-    #[test]
-    fn test_0xaa_tax_negative_flag() {
-        let mut cpu = CPU::new();
-        cpu.load_and_run(vec![0xa9, 0x80, 0xaa, 0x00]);
-
-        assert!(cpu.status.negative_flag == true);
-    }
-
-    #[test]
-    fn test_0xe8_inx_increment_register_x() {
-        let mut cpu = CPU::new();
-        cpu.load_and_run(vec![0xe8, 0x00]);
-
-        assert_eq!(cpu.index_register_x, 1);
-        assert!(cpu.status.zero_flag == false);
-        assert!(cpu.status.negative_flag == false);
-    }
-
-    #[test]
-    fn test_0xe8_inx_zero_flag() {
-        let mut cpu = CPU::new();
-        cpu.load_and_run(vec![0xa9, 0xff, 0xaa, 0xe8, 0x00]);
-
-        assert_eq!(cpu.index_register_x, 0);
-        assert!(cpu.status.zero_flag == true);
-    }
-    #[test]
-    fn test_0xe8_inx_overflow() {
-        let mut cpu = CPU::new();
-        cpu.load_and_run(vec![0xa9, 0xff, 0xaa, 0xe8, 0xe8, 0x00]);
-
-        assert_eq!(cpu.index_register_x, 1)
-    }
-
-    #[test]
-    fn test_0xe8_inx_negative_flag() {
-        let mut cpu = CPU::new();
-        cpu.load_and_run(vec![0xa9, 0x80, 0xaa, 0xe8, 0x00]);
-
-        assert!(cpu.status.negative_flag == true);
-    }
-
-    #[test]
-    fn test_5_ops_working_together() {
-        let mut cpu = CPU::new();
-        cpu.load_and_run(vec![0xa9, 0xc0, 0xaa, 0xe8, 0x00]);
-
-        assert_eq!(cpu.index_register_x, 0xc1)
-    }
-
-    #[test]
-    fn test_mem_read_write() {
-        let mut cpu = CPU::new();
-
-        cpu.mem_write(0x8000, 0xAB);
-        cpu.mem_write(0x8001, 0xCD);
-
-        let data1 = cpu.mem_read(0x8000);
-        let data2 = cpu.mem_read(0x8001);
-
-        assert_eq!(data1, 0xAB);
-        assert_eq!(data2, 0xCD);
-    }
-
-    #[test]
-    fn test_mem_read_write_u16() {
-        let mut cpu = CPU::new();
-        cpu.mem_write_u16(0x8000, 0xABCD);
-        let value = cpu.mem_read_u16(0x8000);
-        assert_eq!(value, 0xABCD)
-    }
-
-    #[test]
-    fn test_load() {
-        let mut cpu = CPU::new();
-        let program: Vec<u8> = vec![0x01, 0x02, 0x03];
-        cpu.load(program.clone());
-
-        for (i, &byte) in program.iter().enumerate() {
-            let memory_index = 0x8000 + i;
-            assert!(
-                memory_index < cpu.memory.len(),
-                "Memory index out of range: 0x{:X}",
-                memory_index
-            );
-            assert_eq!(cpu.memory[memory_index], byte);
+            #[test]
+            fn test_lda_indirect_y() {
+                let mut cpu = CPU::new();
+                cpu.mem_write_u16(0x80, 0x2030);
+                cpu.mem_write(0x2035, 0xE6);
+                cpu.load(vec![0xB1, 0x80, 0x00]);
+                cpu.reset();
+                cpu.index_register_y = 0x05;
+                cpu.run();
+                assert_eq!(cpu.accumulator, 0xE6);
+            }
         }
-        assert_eq!(cpu.program_counter, 0);
+        mod tax {
+
+            use super::*;
+
+            #[test]
+            fn test_tax_effects() {
+                let mut cpu = CPU::new();
+                cpu.load_and_run(vec![0xa9, 0x10, 0xaa, 0x00]);
+
+                assert_eq!(cpu.index_register_x, 16);
+                assert!(cpu.status.zero_flag == false);
+                assert!(cpu.status.negative_flag == false);
+
+                cpu.load_and_run(vec![0xa9, 0x00, 0xaa, 0x00]);
+
+                assert!(cpu.status.zero_flag == true);
+
+                cpu.load_and_run(vec![0xa9, 0x80, 0xaa, 0x00]);
+
+                assert!(cpu.status.negative_flag == true);
+            }
+        }
+        mod imx {
+
+            use super::*;
+
+            #[test]
+            fn test_inx_effects() {
+                let mut cpu = CPU::new();
+                cpu.load_and_run(vec![0xe8, 0x00]);
+
+                assert_eq!(cpu.index_register_x, 1);
+                assert!(cpu.status.zero_flag == false);
+                assert!(cpu.status.negative_flag == false);
+
+                cpu.load_and_run(vec![0xa9, 0xff, 0xaa, 0xe8, 0x00]);
+
+                assert_eq!(cpu.index_register_x, 0);
+                assert!(cpu.status.zero_flag == true);
+
+                cpu.load_and_run(vec![0xa9, 0x80, 0xaa, 0xe8, 0x00]);
+
+                assert!(cpu.status.negative_flag == true);
+
+                cpu.load_and_run(vec![0xa9, 0xff, 0xaa, 0xe8, 0xe8, 0x00]);
+
+                assert_eq!(cpu.index_register_x, 1)
+            }
+        }
+        mod brk {
+
+            use super::*;
+
+            #[test]
+            fn test_brk_effects() {
+                let mut cpu = CPU::new();
+                cpu.load_and_run(vec![0x00]);
+                assert_eq!(
+                    cpu.program_counter, 0x8001,
+                    "オペコードBRKが実行された際のプログラムカウンタが正しくありません"
+                );
+            }
+        }
     }
 
-    #[test]
-    fn test_reset() {
-        let mut cpu = CPU::new();
-        cpu.accumulator = 1;
-        cpu.index_register_x = 1;
-        cpu.status.negative_flag = true;
-        cpu.reset();
-        assert_eq!(cpu.accumulator, 0,);
-        assert_eq!(cpu.index_register_x, 0,);
-        assert_eq!(cpu.status.negative_flag, false);
+    mod operand_address_tests {
+
+        use super::*;
+
+        #[test]
+        fn test_get_operand_address() {
+            let mut cpu = CPU::new();
+            cpu.program_counter = 0x90;
+            let mut mode = AddressingMode::Immediate;
+            let mut effective_address = cpu.get_operand_address(&mode);
+            assert_eq!(
+                effective_address, cpu.program_counter,
+                "オペランドアドレスがプログラムカウンタと一致していません"
+            );
+
+            cpu.reset();
+            cpu.memory[cpu.program_counter as usize] = 0x44;
+            mode = AddressingMode::ZeroPage;
+            effective_address = cpu.get_operand_address(&mode);
+            assert_eq!(effective_address, 0x44);
+
+            cpu.reset();
+            mode = AddressingMode::ZeroPage;
+            for address in 0x00..=0xFF {
+                cpu.memory[cpu.program_counter as usize] = address;
+                effective_address = cpu.get_operand_address(&mode);
+                assert_eq!(effective_address, address as u16);
+            }
+
+            cpu.reset();
+            cpu.memory[cpu.program_counter as usize] = 0x44;
+            cpu.index_register_x = 0x10;
+            mode = AddressingMode::ZeroPage_X;
+            effective_address = cpu.get_operand_address(&mode);
+            assert_eq!(effective_address, 0x54);
+
+            cpu.reset();
+            cpu.index_register_y = 0x02;
+            cpu.memory[cpu.program_counter as usize] = 0x50;
+            mode = AddressingMode::ZeroPage_Y;
+            effective_address = cpu.get_operand_address(&mode);
+            assert_eq!(effective_address, 0x52);
+
+            cpu.reset();
+            cpu.memory[cpu.program_counter as usize] = 0x80;
+            cpu.memory[cpu.program_counter.wrapping_add(1) as usize] = 0x49;
+            mode = AddressingMode::Absolute;
+            effective_address = cpu.get_operand_address(&mode);
+            assert_eq!(effective_address, 0x4980);
+
+            cpu.reset();
+            cpu.index_register_x = 0x20;
+            cpu.memory[cpu.program_counter as usize] = 0x30;
+            cpu.memory[cpu.program_counter.wrapping_add(1) as usize] = 0x98;
+            mode = AddressingMode::Absolute_X;
+            effective_address = cpu.get_operand_address(&mode);
+            assert_eq!(effective_address, 0x9850);
+
+            cpu.reset();
+            cpu.index_register_y = 0x42;
+            cpu.memory[cpu.program_counter as usize] = 0x50;
+            cpu.memory[cpu.program_counter.wrapping_add(1) as usize] = 0xE0;
+            mode = AddressingMode::Absolute_Y;
+            effective_address = cpu.get_operand_address(&mode);
+            assert_eq!(effective_address, 0xE092);
+
+            cpu.reset();
+            cpu.memory[cpu.program_counter as usize] = 0x22;
+            cpu.memory[0x22] = 0x50;
+            cpu.memory[0x23] = 0xAC;
+            mode = AddressingMode::Indirect;
+            effective_address = cpu.get_operand_address(&mode);
+            assert_eq!(effective_address, 0xAC50);
+
+            cpu.reset();
+            cpu.memory[cpu.program_counter as usize] = 0x40;
+            cpu.index_register_x = 0x05;
+            cpu.memory[0x45] = 0x10;
+            cpu.memory[0x46] = 0x09;
+            mode = AddressingMode::Indirect_X;
+            effective_address = cpu.get_operand_address(&mode);
+            assert_eq!(effective_address, 0x0910);
+
+            cpu.reset();
+            cpu.memory[cpu.program_counter as usize] = 0xA0;
+            cpu.index_register_y = 0x05;
+            cpu.memory[0xA0] = 0x50;
+            cpu.memory[0xA1] = 0xB2;
+            mode = AddressingMode::Indirect_Y;
+            effective_address = cpu.get_operand_address(&mode);
+            assert_eq!(effective_address, 0xB255);
+
+            cpu.reset();
+            cpu.memory[cpu.program_counter as usize] = 0x60;
+            mode = AddressingMode::Relative;
+            effective_address = cpu.get_operand_address(&mode);
+            assert_eq!(effective_address, 0x60);
+
+            cpu.reset();
+            cpu.accumulator = 0x42;
+            mode = AddressingMode::Accumulator;
+            effective_address = cpu.get_operand_address(&mode);
+            assert_eq!(effective_address, 0x42);
+
+            cpu.reset();
+            mode = AddressingMode::Implicit;
+            effective_address = cpu.get_operand_address(&mode);
+            assert_eq!(effective_address, 0);
+        }
     }
 
-    #[test]
-    fn test_get_operand_address_immediate() {
-        let cpu = CPU::new();
-        let mode = AddressingMode::Immediate;
-        let result = cpu.get_operand_address(&mode);
-        assert_eq!(result, cpu.program_counter);
+    mod memory_access {
+
+        use super::*;
+
+        #[test]
+        fn test_mem_read_write() {
+            let mut cpu = CPU::new();
+
+            cpu.mem_write(0x8000, 0xAB);
+            cpu.mem_write(0x8001, 0xCD);
+
+            let data1 = cpu.mem_read(0x8000);
+            let data2 = cpu.mem_read(0x8001);
+
+            assert_eq!(data1, 0xAB);
+            assert_eq!(data2, 0xCD);
+        }
+
+        #[test]
+        fn test_mem_read_write_u16() {
+            let mut cpu = CPU::new();
+            cpu.mem_write_u16(0x8000, 0xABCD);
+            let value = cpu.mem_read_u16(0x8000);
+            assert_eq!(value, 0xABCD)
+        }
     }
 
-    #[test]
-    fn test_get_operand_address_zero_page() {
-        let mut cpu = CPU::new();
-        cpu.memory[cpu.program_counter as usize] = 0x44;
-        let mode = AddressingMode::ZeroPage;
-        let result = cpu.get_operand_address(&mode);
-        assert_eq!(result, 0x44);
-    }
+    mod cpu_instruction_tests {
 
-    #[test]
-    fn test_get_operand_address_zero_page_x() {
-        let mut cpu = CPU::new();
-        cpu.index_register_x = 0x10;
-        cpu.memory[cpu.program_counter as usize] = 0x44;
-        let mode = AddressingMode::ZeroPage_X;
-        let result = cpu.get_operand_address(&mode);
-        assert_eq!(result, 0x54);
-    }
+        use super::*;
 
-    #[test]
-    fn test_get_operand_address_zero_page_y() {
-        let mut cpu = CPU::new();
-        cpu.index_register_y = 0x02;
-        cpu.memory[cpu.program_counter as usize] = 0x50;
-        let mode = AddressingMode::ZeroPage_Y;
-        let result = cpu.get_operand_address(&mode);
-        assert_eq!(result, 0x52);
-    }
-    #[test]
-    fn test_get_operand_address_absolute() {
-        let mut cpu = CPU::new();
-        cpu.memory[cpu.program_counter as usize] = 0x80;
-        cpu.memory[cpu.program_counter.wrapping_add(1) as usize] = 0x49;
-        let mode = AddressingMode::Absolute;
-        let result = cpu.get_operand_address(&mode);
-        assert_eq!(result, 0x4980);
-    }
+        #[test]
+        fn test_load() {
+            let mut cpu = CPU::new();
+            let program: Vec<u8> = vec![0x01, 0x02, 0x03];
+            cpu.load(program.clone());
 
-    #[test]
-    fn test_get_operand_address_absolute_x() {
-        let mut cpu = CPU::new();
-        cpu.index_register_x = 0x20;
-        cpu.memory[cpu.program_counter as usize] = 0x30;
-        cpu.memory[cpu.program_counter.wrapping_add(1) as usize] = 0x98;
-        let mode = AddressingMode::Absolute_X;
-        let result = cpu.get_operand_address(&mode);
-        assert_eq!(result, 0x9850);
-    }
+            for (i, &byte) in program.iter().enumerate() {
+                let memory_index = 0x8000 + i;
+                assert!(
+                    memory_index < cpu.memory.len(),
+                    "Memory index out of range: 0x{:X}",
+                    memory_index
+                );
+                assert_eq!(cpu.memory[memory_index], byte);
+            }
+            assert_eq!(cpu.program_counter, 0);
+        }
 
-    #[test]
-    fn test_get_operand_address_absolute_y() {
-        let mut cpu = CPU::new();
-        cpu.index_register_y = 0x42;
-        cpu.memory[cpu.program_counter as usize] = 0x90;
-        cpu.memory[cpu.program_counter.wrapping_add(1) as usize] = 0xE0;
-        let mode = AddressingMode::Absolute_Y;
-        let result = cpu.get_operand_address(&mode);
-        assert_eq!(result, 0xE0D2);
-    }
+        #[test]
+        fn test_reset() {
+            let mut cpu = CPU::new();
+            cpu.accumulator = 1;
+            cpu.index_register_x = 1;
+            cpu.status.negative_flag = true;
+            cpu.reset();
+            assert_eq!(cpu.accumulator, 0);
+            assert_eq!(cpu.index_register_x, 0);
+            assert_eq!(cpu.status.negative_flag, false);
+        }
 
-    #[test]
-    fn test_get_operand_address_indirect() {
-        let mut cpu = CPU::new();
-        cpu.memory[cpu.program_counter as usize] = 0x22;
-        cpu.memory[0x22] = 0x50;
-        cpu.memory[0x23] = 0xAC;
-        let mode = AddressingMode::Indirect;
-        let result = cpu.get_operand_address(&mode);
-        assert_eq!(result, 0xAC50);
-    }
+        #[test]
+        fn test_5_ops_working_together() {
+            let mut cpu = CPU::new();
+            cpu.load_and_run(vec![0xa9, 0xc0, 0xaa, 0xe8, 0x00]);
 
-    #[test]
-    fn test_get_operand_address_indirect_x() {
-        let mut cpu = CPU::new();
-
-        cpu.memory[cpu.program_counter as usize] = 0x40;
-        cpu.index_register_x = 0x05;
-        cpu.memory[0x45] = 0x10;
-        cpu.memory[0x46] = 0x09;
-
-        let mode = AddressingMode::Indirect_X;
-        let result = cpu.get_operand_address(&mode);
-        assert_eq!(result, 0x0910);
-    }
-    #[test]
-    fn test_get_operand_address_indirect_y() {
-        let mut cpu = CPU::new();
-        cpu.memory[cpu.program_counter as usize] = 0xA0;
-        cpu.index_register_y = 0x05;
-        cpu.memory[0xA0] = 0x50;
-        cpu.memory[0xA1] = 0xB2;
-        let mode = AddressingMode::Indirect_Y;
-        let result = cpu.get_operand_address(&mode);
-        assert_eq!(result, 0xB255);
-    }
-
-    #[test]
-    fn test_get_operand_address_relative() {
-        let mut cpu = CPU::new();
-        cpu.memory[cpu.program_counter as usize] = 0x60;
-        let mode = AddressingMode::Relative;
-        let result = cpu.get_operand_address(&mode);
-        assert_eq!(result, 0x60)
-    }
-
-    #[test]
-    fn test_get_operand_address_accumulator() {
-        let mut cpu = CPU::new();
-        cpu.accumulator = 0x42;
-        let mode = AddressingMode::Accumulator;
-        let result = cpu.get_operand_address(&mode);
-        assert_eq!(result, 0x42);
-    }
-    #[test]
-    fn test_get_operand_address_implicit() {
-        let cpu = CPU::new();
-        let mode = AddressingMode::Implicit;
-        let result = cpu.get_operand_address(&mode);
-        assert_eq!(result, 0);
+            assert_eq!(cpu.index_register_x, 0xc1)
+        }
     }
 }


### PR DESCRIPTION
アドレッシングモード毎のLDAテストコードの追加と
テストを構造化した

変更内容:
- アドレッシングモードに応じたLDA命令のテストを実施
- テストを構造化して分類し、テストケース名も適切に命名

#74,#66,#6