### PR TITLE
Issue/Opcode_Implementation#65

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -421,6 +421,8 @@ impl CPU {
                     self.status.intersects(ProcessorStatus::NEGATIVE),
                 ),
                 BIT => self.bit(&opcode.mode),
+                CLC => self.status.set(ProcessorStatus::CARRY, false),
+                SEC => self.status.set(ProcessorStatus::CARRY, true),
                 _ => todo!(),
             }
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -427,6 +427,7 @@ impl CPU {
                 SEI => self.status.set(ProcessorStatus::INTERRUPT_DISABLE, true),
                 CLD => self.status.set(ProcessorStatus::DECIMAL, false),
                 SED => self.status.set(ProcessorStatus::DECIMAL, true),
+                CLV => self.status.set(ProcessorStatus::OVERFLOW, false),
                 _ => todo!(),
             }
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -425,6 +425,8 @@ impl CPU {
                 SEC => self.status.set(ProcessorStatus::CARRY, true),
                 CLI => self.status.set(ProcessorStatus::INTERRUPT_DISABLE, false),
                 SEI => self.status.set(ProcessorStatus::INTERRUPT_DISABLE, true),
+                CLD => self.status.set(ProcessorStatus::DECIMAL, false),
+                SED => self.status.set(ProcessorStatus::DECIMAL, true),
                 _ => todo!(),
             }
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -423,6 +423,8 @@ impl CPU {
                 BIT => self.bit(&opcode.mode),
                 CLC => self.status.set(ProcessorStatus::CARRY, false),
                 SEC => self.status.set(ProcessorStatus::CARRY, true),
+                CLI => self.status.set(ProcessorStatus::INTERRUPT_DISABLE, false),
+                SEI => self.status.set(ProcessorStatus::INTERRUPT_DISABLE, true),
                 _ => todo!(),
             }
 

--- a/tests/cpu_tests.rs
+++ b/tests/cpu_tests.rs
@@ -838,6 +838,24 @@ mod tests {
                     );
                 }
             }
+            mod decimal_mode {
+                use super::*;
+
+                #[test]
+                fn test_decimal_mode() {
+                    let mut cpu = run(vec![0xD8, 0x00], |cpu| {
+                        cpu.status.set(ProcessorStatus::DECIMAL, true)
+                    });
+
+                    assert_eq!(cpu.status.contains(ProcessorStatus::DECIMAL), false);
+
+                    cpu = run(vec![0xF8, 0x00], |cpu| {
+                        cpu.status.set(ProcessorStatus::DECIMAL, false)
+                    });
+
+                    assert_eq!(cpu.status.contains(ProcessorStatus::DECIMAL), true);
+                }
+            }
         }
     }
     mod operand_address_tests {

--- a/tests/cpu_tests.rs
+++ b/tests/cpu_tests.rs
@@ -760,6 +760,7 @@ mod tests {
             }
         }
         mod bit {
+
             use super::*;
 
             #[test]
@@ -791,6 +792,28 @@ mod tests {
                         .contains(ProcessorStatus::OVERFLOW | ProcessorStatus::NEGATIVE),
                     true
                 );
+            }
+        }
+        mod flag {
+            use super::*;
+
+            mod carry {
+                use super::*;
+
+                #[test]
+                fn test_carry() {
+                    let mut cpu = run(vec![0x18, 0x00], |cpu| {
+                        cpu.status.set(ProcessorStatus::CARRY, true)
+                    });
+
+                    assert_eq!(cpu.status.contains(ProcessorStatus::CARRY), false);
+
+                    cpu = run(vec![0x38, 0x00], |cpu| {
+                        cpu.status.set(ProcessorStatus::CARRY, false)
+                    });
+
+                    assert_eq!(cpu.status.contains(ProcessorStatus::CARRY), true);
+                }
             }
         }
     }

--- a/tests/cpu_tests.rs
+++ b/tests/cpu_tests.rs
@@ -856,6 +856,18 @@ mod tests {
                     assert_eq!(cpu.status.contains(ProcessorStatus::DECIMAL), true);
                 }
             }
+            mod overflow {
+                use super::*;
+
+                #[test]
+                fn test_overflow() {
+                    let cpu = run(vec![0xB8, 0x00], |cpu| {
+                        cpu.status.set(ProcessorStatus::OVERFLOW, true)
+                    });
+
+                    assert_eq!(cpu.status.contains(ProcessorStatus::OVERFLOW), false);
+                }
+            }
         }
     }
     mod operand_address_tests {

--- a/tests/cpu_tests.rs
+++ b/tests/cpu_tests.rs
@@ -760,7 +760,6 @@ mod tests {
             }
         }
         mod bit {
-
             use super::*;
 
             #[test]
@@ -813,6 +812,30 @@ mod tests {
                     });
 
                     assert_eq!(cpu.status.contains(ProcessorStatus::CARRY), true);
+                }
+            }
+            mod interrupt_disable {
+                use super::*;
+
+                #[test]
+                fn test_interrupt_disable() {
+                    let mut cpu = run(vec![0x58, 0x00], |cpu| {
+                        cpu.status.set(ProcessorStatus::INTERRUPT_DISABLE, true)
+                    });
+
+                    assert_eq!(
+                        cpu.status.contains(ProcessorStatus::INTERRUPT_DISABLE),
+                        false
+                    );
+
+                    cpu = run(vec![0x78, 0x00], |cpu| {
+                        cpu.status.set(ProcessorStatus::INTERRUPT_DISABLE, false)
+                    });
+
+                    assert_eq!(
+                        cpu.status.contains(ProcessorStatus::INTERRUPT_DISABLE),
+                        true
+                    );
                 }
             }
         }


### PR DESCRIPTION
各フラグのセット、クリアを行う命令の実装。

変更点:
-キャリーフラグに影響するCLC,SEC命令の実装
-割込み禁止フラグに影響するCLI,SEI命令の実装
-10進数モードフラグに影響するCLD,SED命令の実装
-オーバーフローフラグに影響するCLV命令の実装

#65,#95,#96,#97,#98




