### PR TITLE
[Impl #101] add CMP,CPX,CPY

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -350,6 +350,16 @@ impl CPU {
         self.status.bits() & reg.bits()
     }
 
+    fn compare(&mut self, mode: &AddressingMode, register: u8) {
+        let value = self.fetch_data(mode);
+
+        if register >= value {
+            self.status.insert(ProcessorStatus::CARRY);
+        }
+
+        self.update_zero_and_negative_flags(register.wrapping_sub(value))
+    }
+
     fn fetch_data(&self, mode: &AddressingMode) -> u8 {
         let addr = self.get_operand_address(mode);
         match mode {
@@ -428,6 +438,9 @@ impl CPU {
                 CLD => self.status.remove(ProcessorStatus::DECIMAL),
                 SED => self.status.insert(ProcessorStatus::DECIMAL),
                 CLV => self.status.remove(ProcessorStatus::OVERFLOW),
+                CMP => self.compare(&opcode.mode, self.accumulator),
+                CPX => self.compare(&opcode.mode, self.index_register_x),
+                CPY => self.compare(&opcode.mode, self.index_register_y),
                 _ => todo!(),
             }
 

--- a/tests/cpu_tests.rs
+++ b/tests/cpu_tests.rs
@@ -869,7 +869,162 @@ mod tests {
                 }
             }
         }
+        mod cmp {
+            use super::*;
+            mod cmp {
+                use super::*;
+
+                #[test]
+                fn test_cmp_greater_than_or_eq() {
+                    let cpu = run(vec![0xC9, 0x10, 0x00], |cpu| {
+                        cpu.accumulator = 0x50;
+                    });
+
+                    // accumulator > memory
+                    assert_eq!(cpu.status.contains(ProcessorStatus::CARRY), true);
+                    assert_eq!(
+                        cpu.status
+                            .contains(ProcessorStatus::ZERO | ProcessorStatus::NEGATIVE),
+                        false
+                    );
+                }
+                #[test]
+                fn test_cmp_eq() {
+                    let cpu = run(vec![0xC9, 0x50, 0x00], |cpu| {
+                        cpu.accumulator = 0x50;
+                    });
+
+                    // accumulator = memory
+                    assert_eq!(
+                        cpu.status
+                            .contains(ProcessorStatus::CARRY | ProcessorStatus::ZERO),
+                        true
+                    );
+                    assert_eq!(cpu.status.contains(ProcessorStatus::NEGATIVE), false);
+                }
+                #[test]
+                fn test_cmp_less_than() {
+                    // accumulator < memory
+                    let cpu = run(vec![0xC9, 0xB8, 0x00], |cpu| {
+                        cpu.accumulator = 0x10;
+                        cpu.mem_write(0xB8, 0x50);
+                    });
+
+                    assert_eq!(
+                        cpu.status.contains(
+                            ProcessorStatus::CARRY
+                                | ProcessorStatus::ZERO
+                                | ProcessorStatus::NEGATIVE
+                        ),
+                        false
+                    );
+                    assert_eq!(cpu.status.contains(ProcessorStatus::NEGATIVE), false);
+                }
+
+                mod cpx {
+                    use super::*;
+
+                    #[test]
+                    fn test_cpx_greater_than_or_eq() {
+                        let cpu = run(vec![0xE0, 0x10, 0x00], |cpu| {
+                            cpu.index_register_x = 0x50;
+                        });
+
+                        // index X > memory
+                        assert_eq!(cpu.status.contains(ProcessorStatus::CARRY), true);
+                        assert_eq!(
+                            cpu.status
+                                .contains(ProcessorStatus::ZERO | ProcessorStatus::NEGATIVE),
+                            false
+                        );
+                    }
+                    #[test]
+                    fn test_cpx_eq() {
+                        let cpu = run(vec![0xE0, 0x50, 0x00], |cpu| {
+                            cpu.index_register_x = 0x50;
+                        });
+
+                        // index X = memory
+                        assert_eq!(
+                            cpu.status
+                                .contains(ProcessorStatus::CARRY | ProcessorStatus::ZERO),
+                            true
+                        );
+                        assert_eq!(cpu.status.contains(ProcessorStatus::NEGATIVE), false);
+                    }
+                    #[test]
+                    fn test_cpx_less_than() {
+                        // index X < memory
+                        let cpu = run(vec![0xE0, 0xB8, 0x00], |cpu| {
+                            cpu.index_register_x = 0x10;
+                            cpu.mem_write(0xB8, 0x50);
+                        });
+
+                        assert_eq!(
+                            cpu.status.contains(
+                                ProcessorStatus::CARRY
+                                    | ProcessorStatus::ZERO
+                                    | ProcessorStatus::NEGATIVE
+                            ),
+                            false
+                        );
+                        assert_eq!(cpu.status.contains(ProcessorStatus::NEGATIVE), false);
+                    }
+                }
+                mod cpy {
+                    use super::*;
+
+                    #[test]
+                    fn test_cpy_greater_than_or_eq() {
+                        let cpu = run(vec![0xC0, 0x10, 0x00], |cpu| {
+                            cpu.index_register_y = 0x50;
+                        });
+
+                        // index Y > memory
+                        assert_eq!(cpu.status.contains(ProcessorStatus::CARRY), true);
+                        assert_eq!(
+                            cpu.status
+                                .contains(ProcessorStatus::ZERO | ProcessorStatus::NEGATIVE),
+                            false
+                        );
+                    }
+                    #[test]
+                    fn test_cpy_eq() {
+                        let cpu = run(vec![0xC0, 0x50, 0x00], |cpu| {
+                            cpu.index_register_y = 0x50;
+                        });
+
+                        // index Y = memory
+                        assert_eq!(
+                            cpu.status
+                                .contains(ProcessorStatus::CARRY | ProcessorStatus::ZERO),
+                            true
+                        );
+                        assert_eq!(cpu.status.contains(ProcessorStatus::NEGATIVE), false);
+                    }
+                    #[test]
+                    fn test_cpy_less_than() {
+                        // index Y < memory
+                        let cpu = run(vec![0xC0, 0xB8, 0x00], |cpu| {
+                            cpu.index_register_y = 0x10;
+                            cpu.mem_write(0xB8, 0x50);
+                        });
+
+                        assert_eq!(
+                            cpu.status.contains(
+                                ProcessorStatus::CARRY
+                                    | ProcessorStatus::ZERO
+                                    | ProcessorStatus::NEGATIVE
+                            ),
+                            false
+                        );
+                        assert_eq!(cpu.status.contains(ProcessorStatus::NEGATIVE), false);
+                    }
+                }
+            }
+        }
     }
+
     mod operand_address_tests {
 
         use super::*;


### PR DESCRIPTION
比較命令を実装

変更点:
- CPUに比較実行用のcompareメソッドを追加
- CMP、CPX、CPY命令の実装
- CMP、CPX、CPY命令のテストケースを追加

#65,#101