### PR TITLE
[Impl #105] add INC,INY

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -182,9 +182,22 @@ impl CPU {
         self.update_zero_and_negative_flags(self.index_register_x)
     }
 
+    fn inc(&mut self, mode: &AddressingMode) {
+        let addr = self.get_operand_address(mode);
+        let value = self.mem_read(addr);
+        let incremented_value = value.wrapping_add(1);
+        self.mem_write(addr, incremented_value);
+        self.update_zero_and_negative_flags(incremented_value);
+    }
+
     fn inx(&mut self) {
         self.index_register_x = self.index_register_x.wrapping_add(1);
         self.update_zero_and_negative_flags(self.index_register_x)
+    }
+
+    fn iny(&mut self) {
+        self.index_register_y = self.index_register_y.wrapping_add(1);
+        self.update_zero_and_negative_flags(self.index_register_y)
     }
 
     fn dec(&mut self, mode: &AddressingMode) {
@@ -417,7 +430,9 @@ impl CPU {
                     self.lda(&opcode.mode);
                 }
                 TAX => self.tax(),
+                INC => self.inc(&opcode.mode),
                 INX => self.inx(),
+                INY => self.iny(),
                 DEC => self.dec(&opcode.mode),
                 DEX => self.dex(),
                 DEY => self.dey(),

--- a/tests/cpu_tests.rs
+++ b/tests/cpu_tests.rs
@@ -1051,8 +1051,28 @@ mod tests {
                 assert_eq!(cpu.status.contains(ProcessorStatus::NEGATIVE), false);
             }
         }
-    }
 
+        mod increment {
+            use super::*;
+
+            #[test]
+            fn test_inc_memory() {
+                let cpu = run(vec![0xE6, 0x20, 0x00], |cpu| {
+                    cpu.mem_write(0x20, 0x70);
+                });
+                assert_eq!(cpu.mem_read(0x20), 0x71);
+                assert_eq!(cpu.status.contains(ProcessorStatus::NEGATIVE), false);
+            }
+            #[test]
+            fn test_inc_index_y() {
+                let cpu = run(vec![0xC8, 0x00], |cpu| {
+                    cpu.index_register_y = 0x70;
+                });
+                assert_eq!(cpu.index_register_y, 0x71);
+                assert_eq!(cpu.status.contains(ProcessorStatus::NEGATIVE), false);
+            }
+        }
+    }
     mod operand_address_tests {
 
         use super::*;


### PR DESCRIPTION
[Impl #105] add INC,INY

インクリメント命令を実装

変更点:
- メモリの値を加算するINC命令を実装
- レジスタYの値を加算するINY命令を実装

留意点:
- レジスタXの値を加算するINX命令は#26にて実装済み

#65,#105