### PR TITLE
Issue/Opcode_Implementation#65

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -191,6 +191,21 @@ impl CPU {
         self.update_zero_and_negative_flags(self.index_register_y)
     }
 
+    fn sta(&mut self, mode: &AddressingMode) {
+        let addr = self.get_operand_address(mode);
+        self.mem_write(addr, self.accumulator);
+    }
+
+    fn stx(&mut self, mode: &AddressingMode) {
+        let addr = self.get_operand_address(mode);
+        self.mem_write(addr, self.index_register_x);
+    }
+
+    fn sty(&mut self, mode: &AddressingMode) {
+        let addr = self.get_operand_address(mode);
+        self.mem_write(addr, self.index_register_y);
+    }
+
     fn tax(&mut self) {
         self.index_register_x = self.accumulator;
         self.update_zero_and_negative_flags(self.index_register_x)
@@ -443,6 +458,9 @@ impl CPU {
                 LDA => self.lda(&opcode.mode),
                 LDX => self.ldx(&opcode.mode),
                 LDY => self.ldy(&opcode.mode),
+                STA => self.sta(&opcode.mode),
+                STX => self.stx(&opcode.mode),
+                STY => self.sty(&opcode.mode),
                 TAX => self.tax(),
                 INC => self.inc(&opcode.mode),
                 INX => self.inx(),

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -440,15 +440,9 @@ impl CPU {
                 .expect(&format!("OpCode: {:x} is not found", code));
 
             match opcode.mnemonic {
-                LDA => {
-                    self.lda(&opcode.mode);
-                }
-                LDX => {
-                    self.ldx(&opcode.mode);
-                }
-                LDY => {
-                    self.ldy(&opcode.mode);
-                }
+                LDA => self.lda(&opcode.mode),
+                LDX => self.ldx(&opcode.mode),
+                LDY => self.ldy(&opcode.mode),
                 TAX => self.tax(),
                 INC => self.inc(&opcode.mode),
                 INX => self.inx(),

--- a/tests/cpu_tests.rs
+++ b/tests/cpu_tests.rs
@@ -1095,6 +1095,39 @@ mod tests {
                 assert_eq!(cpu.index_register_y, 0x10);
             }
         }
+        mod store {
+            use super::*;
+
+            #[test]
+            fn store_accumulator_for_mem() {
+                let cpu = run(vec![0x85, 0xF0, 0x00], |cpu| {
+                    cpu.accumulator = 0x90;
+                    cpu.mem_write(0xF0, 0x00);
+                });
+
+                assert_eq!(cpu.mem_read(0xF0), cpu.accumulator);
+            }
+
+            #[test]
+            fn store_register_x_for_mem() {
+                let cpu = run(vec![0x86, 0xF0, 0x00], |cpu| {
+                    cpu.index_register_x = 0x90;
+                    cpu.mem_write(0xF0, 0x00);
+                });
+
+                assert_eq!(cpu.mem_read(0xF0), cpu.index_register_x);
+            }
+
+            #[test]
+            fn store_register_y_for_mem() {
+                let cpu = run(vec![0x84, 0xF0, 0x00], |cpu| {
+                    cpu.index_register_x = 0x90;
+                    cpu.mem_write(0xF0, 0x00);
+                });
+
+                assert_eq!(cpu.mem_read(0xF0), cpu.index_register_y);
+            }
+        }
     }
     mod operand_address_tests {
 


### PR DESCRIPTION
レジスタからメモリへのデータストア命令を実装

変更点:
- アキュムレータの値をメモリにストアするSTA命令を実装
- レジスタXの値をメモリにストアするSTX命令を実装
- レジスタYの値をメモリにストアするSTY命令を実装

#6,#65
