### PR TITLE
[Impl #114] add TAY,TYA,TXA

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -211,6 +211,21 @@ impl CPU {
         self.update_zero_and_negative_flags(self.index_register_x)
     }
 
+    fn tay(&mut self) {
+        self.index_register_y = self.accumulator;
+        self.update_zero_and_negative_flags(self.index_register_y)
+    }
+
+    fn tya(&mut self) {
+        self.accumulator = self.index_register_y;
+        self.update_zero_and_negative_flags(self.accumulator)
+    }
+
+    fn txa(&mut self) {
+        self.accumulator = self.index_register_x;
+        self.update_zero_and_negative_flags(self.accumulator)
+    }
+
     fn inc(&mut self, mode: &AddressingMode) {
         let addr = self.get_operand_address(mode);
         let value = self.mem_read(addr);
@@ -462,6 +477,9 @@ impl CPU {
                 STX => self.stx(&opcode.mode),
                 STY => self.sty(&opcode.mode),
                 TAX => self.tax(),
+                TAY => self.tay(),
+                TYA => self.tya(),
+                TXA => self.txa(),
                 INC => self.inc(&opcode.mode),
                 INX => self.inx(),
                 INY => self.iny(),

--- a/tests/cpu_tests.rs
+++ b/tests/cpu_tests.rs
@@ -1128,6 +1128,33 @@ mod tests {
                 assert_eq!(cpu.mem_read(0xF0), cpu.index_register_y);
             }
         }
+        mod transfer {
+            use super::*;
+
+            #[test]
+            fn test_accumlator_to_register_y() {
+                let cpu = run(vec![0xA8, 0x00], |cpu| {
+                    cpu.accumulator = 0x90;
+                });
+                assert_eq!(cpu.index_register_y, cpu.accumulator);
+            }
+
+            #[test]
+            fn test_register_y_to_accumlator() {
+                let cpu = run(vec![0xA8, 0x00], |cpu| {
+                    cpu.index_register_y = 0x90;
+                });
+                assert_eq!(cpu.accumulator, cpu.index_register_y);
+            }
+
+            #[test]
+            fn test_register_x_to_accumlator() {
+                let cpu = run(vec![0x8A, 0x00], |cpu| {
+                    cpu.index_register_x = 0x90;
+                });
+                assert_eq!(cpu.accumulator, cpu.index_register_x);
+            }
+        }
     }
     mod operand_address_tests {
 


### PR DESCRIPTION
コピー命令を実装

変更点:
- アキュムレータの値をレジスタYにコピーするTAY命令を実装
- レジスタYの値をアキュムレータにコピーするTAY命令を実装
- レジスタXの値をアキュムレータにコピーするTAX命令を実装

留意点:
- アキュムレータの値をレジスタXにコピーするTAX命令は#13にて実装済み 


#65,#114