### PR TITLE
Issue/Opcode_Implementation#65

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -442,6 +442,14 @@ impl CPU {
         self.push(self.accumulator);
     }
 
+    fn php(&mut self) {
+        self.push(self.status.bits());
+    }
+
+    fn plp(&mut self) {
+        self.status = ProcessorStatus::from_bits_truncate(self.pull());
+    }
+
     fn pla(&mut self) {
         self.accumulator = self.pull();
         self.update_zero_and_negative_flags(self.accumulator)
@@ -559,6 +567,8 @@ impl CPU {
                 NOP => {}
                 PHA => self.pha(),
                 PLA => self.pla(),
+                PHP => self.php(),
+                PLP => self.plp(),
                 _ => todo!(),
             }
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -41,6 +41,7 @@ pub struct CPU {
     pub program_counter: u16,
     pub index_register_x: u8,
     pub index_register_y: u8,
+    pub stack_pointer: u8,
     pub memory: [u8; 0x10000],
 }
 
@@ -52,6 +53,7 @@ impl CPU {
             program_counter: 0,
             index_register_x: 0,
             index_register_y: 0,
+            stack_pointer: 0xFF,
             memory: [0; 0x10000],
         }
     }
@@ -154,6 +156,7 @@ impl CPU {
         self.accumulator = 0;
         self.index_register_x = 0;
         self.index_register_y = 0;
+        self.stack_pointer = 0xff;
         self.status = ProcessorStatus::empty();
 
         self.program_counter = self.mem_read_u16(0xfffc);
@@ -435,6 +438,32 @@ impl CPU {
         self.update_zero_and_negative_flags(register.wrapping_sub(value))
     }
 
+    fn pha(&mut self) {
+        self.push(self.accumulator);
+    }
+
+    fn pla(&mut self) {
+        self.accumulator = self.pull();
+        self.update_zero_and_negative_flags(self.accumulator)
+    }
+
+    fn push(&mut self, data: u8) {
+        let addr = self.get_stack_addr();
+        self.mem_write(addr, data);
+        self.stack_pointer = self.stack_pointer.wrapping_sub(1);
+    }
+
+    fn pull(&mut self) -> u8 {
+        self.stack_pointer = self.stack_pointer.wrapping_add(1);
+        let addr = self.get_stack_addr();
+        let data = self.mem_read(addr);
+        data
+    }
+
+    fn get_stack_addr(&self) -> u16 {
+        0x0100 | (self.stack_pointer as u16)
+    }
+
     fn fetch_data(&self, mode: &AddressingMode) -> u8 {
         let addr = self.get_operand_address(mode);
         match mode {
@@ -528,6 +557,8 @@ impl CPU {
                 CPX => self.compare(&opcode.mode, self.index_register_x),
                 CPY => self.compare(&opcode.mode, self.index_register_y),
                 NOP => {}
+                PHA => self.pha(),
+                PLA => self.pla(),
                 _ => todo!(),
             }
 

--- a/tests/cpu_tests.rs
+++ b/tests/cpu_tests.rs
@@ -1155,6 +1155,39 @@ mod tests {
                 assert_eq!(cpu.accumulator, cpu.index_register_x);
             }
         }
+        mod stack {
+            use super::*;
+
+            mod push {
+                use super::*;
+
+                #[test]
+                fn test_push_accumlator() {
+                    let cpu = run(vec![0x48, 0x00], |cpu| {
+                        cpu.accumulator = 0x90;
+                    });
+                    assert_eq!(cpu.memory[0x1FF], 0x90);
+                    assert_eq!(cpu.stack_pointer, 0xFE);
+                }
+            }
+            mod pull {
+                use super::*;
+
+                #[test]
+                fn test_pull_accumlator() {
+                    let cpu = run(vec![0x48, 0x68, 0x00], |cpu| {
+                        cpu.accumulator = 0x90;
+                    });
+                    assert_eq!(
+                        cpu.status
+                            .contains(ProcessorStatus::CARRY | ProcessorStatus::ZERO),
+                        false
+                    );
+                    assert_eq!(cpu.accumulator, 0x90);
+                    assert_eq!(cpu.stack_pointer, 0xFF);
+                }
+            }
+            }
     }
     mod operand_address_tests {
 

--- a/tests/cpu_tests.rs
+++ b/tests/cpu_tests.rs
@@ -1169,6 +1169,15 @@ mod tests {
                     assert_eq!(cpu.memory[0x1FF], 0x90);
                     assert_eq!(cpu.stack_pointer, 0xFE);
                 }
+                #[test]
+                fn test_push_processor_status() {
+                    let cpu = run(vec![0x08, 0x00], |cpu| {
+                        cpu.status = ProcessorStatus::CARRY | ProcessorStatus::ZERO;
+                    });
+
+                    assert_eq!(cpu.memory[0x1FF], 0x03); // (ProcessorStatus::CARRY | ProcessorStatus::ZERO) to bit flag is 0x03
+                    assert_eq!(cpu.stack_pointer, 0xFE);
+                }
             }
             mod pull {
                 use super::*;
@@ -1186,8 +1195,22 @@ mod tests {
                     assert_eq!(cpu.accumulator, 0x90);
                     assert_eq!(cpu.stack_pointer, 0xFF);
                 }
+
+                #[test]
+                fn test_pull_processor_status() {
+                    let cpu = run(vec![0x08, 0x28, 0x00], |cpu| {
+                        cpu.status = ProcessorStatus::CARRY | ProcessorStatus::ZERO;
+                    });
+
+                    assert_eq!(
+                        cpu.status
+                            .contains(ProcessorStatus::CARRY | ProcessorStatus::ZERO),
+                        true
+                    );
+                    assert_eq!(cpu.stack_pointer, 0xFF);
+                }
             }
-            }
+        }
     }
     mod operand_address_tests {
 


### PR DESCRIPTION
スタックのpushとpull命令を実装

変更点:
- PHA（アキュムレータをプッシュ）：アキュムレータの値をスタックにプッシュする。
- PHP（プロセッサステータスをプッシュ）：プロセッサステータスフラグをスタックにプッシュする。
- PLA（アキュムレータをプル）：スタックから値をプルし、アキュムレータにロードする。
- PLP（プロセッサステータスをプル）：スタックから値をプルし、プロセッサステータスフラグとして設定する。

また、スタックのオーバーフローチェックも実装して、スタックが有効な範囲内に収まるようにした。

#65,#117,#118


