### PR TITLE
Issue/Opcode_Implementation#65

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -481,6 +481,11 @@ impl CPU {
         0x0100 | (self.stack_pointer as u16)
     }
 
+    fn jmp(&mut self, mode: &AddressingMode) {
+        let addr = self.get_operand_address(mode);
+        self.program_counter = addr;
+    }
+
     fn fetch_data(&self, mode: &AddressingMode) -> u8 {
         let addr = self.get_operand_address(mode);
         match mode {
@@ -580,6 +585,7 @@ impl CPU {
                 PLA => self.pla(),
                 PHP => self.php(),
                 PLP => self.plp(),
+                JMP => self.jmp(&opcode.mode),
                 _ => todo!(),
             }
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -470,11 +470,24 @@ impl CPU {
         self.stack_pointer = self.stack_pointer.wrapping_sub(1);
     }
 
+    fn push_u16(&mut self, data: u16) {
+        let hi = (data >> 8) as u8;
+        let lo = (data & 0xff) as u8;
+        self.push(hi);
+        self.push(lo);
+    }
+
     fn pull(&mut self) -> u8 {
         self.stack_pointer = self.stack_pointer.wrapping_add(1);
         let addr = self.get_stack_addr();
         let data = self.mem_read(addr);
         data
+    }
+
+    fn pull_u16(&mut self) -> u16 {
+        let lo = self.pull() as u16;
+        let hi = self.pull() as u16;
+        (hi << 8) | lo
     }
 
     fn get_stack_addr(&self) -> u16 {
@@ -484,6 +497,20 @@ impl CPU {
     fn jmp(&mut self, mode: &AddressingMode) {
         let addr = self.get_operand_address(mode);
         self.program_counter = addr;
+    }
+
+    fn jsr(&mut self, mode: &AddressingMode, opcode_len: &u8) {
+        let addr = self.get_operand_address(mode);
+        let operand_byte = *opcode_len as u16 - 1; //jsrのオペランド部のバイト数
+        let operand_byte_count = operand_byte - 1;
+        let return_addr = self.program_counter + operand_byte_count;
+        self.push_u16(return_addr);
+        self.program_counter = addr;
+    }
+
+    fn rts(&mut self) {
+        let return_addr = self.pull_u16() + 1;
+        self.program_counter = return_addr;
     }
 
     fn fetch_data(&self, mode: &AddressingMode) -> u8 {
@@ -586,6 +613,8 @@ impl CPU {
                 PHP => self.php(),
                 PLP => self.plp(),
                 JMP => self.jmp(&opcode.mode),
+                JSR => self.jsr(&opcode.mode, &opcode.len),
+                RTS => self.rts(),
                 _ => todo!(),
             }
 

--- a/tests/cpu_tests.rs
+++ b/tests/cpu_tests.rs
@@ -1244,6 +1244,24 @@ mod tests {
                 assert_eq!(cpu.program_counter, 0x8901);
             }
         }
+
+        mod subroutine {
+            use super::*;
+
+            #[test]
+            fn test_jsr_rts() {
+                let cpu = run(vec![0x20, 0xAF, 0x80, 0x20, 0x00, 0x9A, 0x00], |cpu| {
+                    cpu.mem_write(0x80AF, 0xA9); //LDA
+                    cpu.mem_write(0x80B0, 0x42); // LDA. 0x42
+                    cpu.mem_write(0x80B1, 0x60); //RTS
+                    cpu.mem_write(0x9A00, 0xE8); //INX
+                    cpu.mem_write(0x9A01, 0x60); //RTS
+                });
+                assert_eq!(cpu.accumulator, 0x42);
+                assert_eq!(cpu.index_register_x, 0x01);
+                assert_eq!(cpu.program_counter, 0x8007);
+            }
+        }
     }
     mod operand_address_tests {
 

--- a/tests/cpu_tests.rs
+++ b/tests/cpu_tests.rs
@@ -1227,6 +1227,23 @@ mod tests {
                 }
             }
         }
+        mod jmp {
+            use super::*;
+
+            #[test]
+            fn test_jmp_absolute() {
+                let cpu = run(vec![0x4C, 0x34, 0x89, 0x00], |_| {});
+                assert_eq!(cpu.program_counter, 0x8935); // JMP命令(0x8934) + BREAKE命令(1)
+            }
+
+            #[test]
+            fn test_jmp_indirect() {
+                let cpu = run(vec![0x6C, 0x80, 0x00], |cpu| {
+                    cpu.mem_write_u16(0x80, 0x8900); //JMP命令(0x8900) + BREAKE命令(1)
+                });
+                assert_eq!(cpu.program_counter, 0x8901);
+            }
+        }
     }
     mod operand_address_tests {
 


### PR DESCRIPTION
JMP、JSR、RTS命令の実装

変更点:
- JMP (Jump) 命令の実装。この命令はプログラムの実行を指定したアドレスにジャンプします。
- JSR (Jump to Subroutine) 命令の実装。この命令はサブルーチンにジャンプし、サブルーチンからの復帰アドレスをスタックにプッシュします。
- RTS (Return from Subroutine) 命令の実装。この命令はサブルーチンからの復帰を行います。

#65,#107,#121