### PR TITLE
Linuxfirst mint/issue132

### DIFF
--- a/src/bus.rs
+++ b/src/bus.rs
@@ -1,0 +1,11 @@
+pub struct Bus {
+    cpu_vram: [u8; 2048],
+}
+
+impl Bus {
+    pub fn new() -> Self {
+        Self {
+            cpu_vram: [0; 2048],
+        }
+    }
+}

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -1,5 +1,7 @@
+use crate::cpu::Mem;
+
 pub struct Bus {
-    cpu_vram: [u8; 2048],
+    pub cpu_vram: [u8; 2048],
 }
 
 impl Bus {
@@ -7,5 +9,109 @@ impl Bus {
         Self {
             cpu_vram: [0; 2048],
         }
+    }
+}
+
+const RAM: u16 = 0x0000;
+const RAM_MIRROR_END: u16 = 0x1FFF;
+const PPU_REGISTERS: u16 = 0x2000;
+const PPU_REGISTERS_MIRROR_END: u16 = 0x3FFF;
+
+impl Mem for Bus {
+    fn mem_read(&self, addr: u16) -> u8 {
+        match addr {
+            RAM..=RAM_MIRROR_END => {
+                let mirror_down_addr = addr & 0b0000_0111_1111_1111;
+                self.cpu_vram[mirror_down_addr as usize]
+            }
+            PPU_REGISTERS..=PPU_REGISTERS_MIRROR_END => {
+                let mirror_down_addr = addr & 0b0010_0000_0000_0111;
+                todo!("PPU is not implemented yet");
+            }
+            _ => {
+                println!("Ignoring mem access at {:#X}", addr);
+                0
+            }
+        }
+    }
+    fn mem_write(&mut self, addr: u16, data: u8) {
+        match addr {
+            RAM..=RAM_MIRROR_END => {
+                let mirror_down_addr = addr & 0b0000_0111_1111_1111;
+                self.cpu_vram[mirror_down_addr as usize] = data;
+            }
+            PPU_REGISTERS..=PPU_REGISTERS_MIRROR_END => {
+                let mirror_down_addr = addr & 0b0010_0000_0000_0111;
+                todo!("PPU is not implemented yet")
+            }
+
+            _ => println!("Ignoring mem write-access at {:#X}", addr),
+        }
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mem_read_ram() {
+        let bus = Bus::new();
+        let addr = 0x0000;
+        let data = bus.mem_read(addr);
+        assert_eq!(data, 0);
+    }
+
+    #[test]
+    fn test_mem_read_ram_mirror() {
+        let bus = Bus::new();
+        let addr = 0x0800;
+        let data = bus.mem_read(addr);
+        assert_eq!(data, 0);
+    }
+
+    // #[test]
+    // fn test_mem_read_ppu_registers() {
+    //     todo!("Implement this test");
+    // }
+
+    // #[test]
+    // fn test_mem_read_ppu_registers_mirror() {
+    //     todo!("Implement this test");
+    // }
+
+    #[test]
+    fn test_mem_read_invalid_address() {
+        let bus = Bus::new();
+        let addr = 0xFFFF;
+        let data = bus.mem_read(addr);
+        assert_eq!(data, 0);
+    }
+
+    #[test]
+    fn test_mem_write_ram() {
+        let mut bus = Bus::new();
+        let addr = 0x0000;
+        let data = 0x42;
+        bus.mem_write(addr, data);
+        assert_eq!(bus.cpu_vram[0], data);
+    }
+
+    #[test]
+    fn test_mem_write_ram_mirror() {
+        let mut bus = Bus::new();
+        let addr = 0x0800;
+        let data = 0x42;
+        bus.mem_write(addr, data);
+        assert_eq!(bus.cpu_vram[0], data);
+    }
+
+    #[test]
+    fn test_mem_write_invalid_address() {
+        let mut bus = Bus::new();
+        let addr = 0xFFFF;
+        let data = 0x42;
+        let result = bus.mem_write(addr, data);
+        // shoud not panic
+        assert_eq!(result, ());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod bus;
 pub mod cpu;
 pub mod opcodes;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+pub mod bus;
 pub mod cpu;
 pub mod opcodes;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,8 @@ pub mod opcodes;
 
 use std::env;
 
-use cpu::CPU;
+use bus::Bus;
+use cpu::{Mem, CPU};
 
 use rand::Rng;
 use sdl2::event::Event;
@@ -50,12 +51,15 @@ fn main() {
         0x60, 0xa2, 0x00, 0xea, 0xea, 0xca, 0xd0, 0xfb, 0x60,
     ];
 
-    let mut cpu = CPU::new();
+    let bus = Bus::new();
+    let mut cpu = CPU::new(bus);
 
-    cpu.memory[0x0600..(0x0600 + game_code.len())].copy_from_slice(&game_code[..]);
+    cpu.bus.cpu_vram[0x0600..(0x0600 + game_code.len())].copy_from_slice(&game_code[..]);
     cpu.mem_write_u16(0xFFFC, 0x0600);
 
     cpu.reset();
+
+    cpu.program_counter = 0x0600;
 
     // init sdl2
     let sdl_context = sdl2::init().unwrap();


### PR DESCRIPTION
バスの実装

**変更内容**
- `bus.rs` Memory構造体を実装してメモリスペース（RAMを含む）を管理。
- `bus.rs`  Memory構造体を拡張して追加のメモリマップデバイスを収容できるようにした。
- `bus.rs` データアクセスと制御を統括するBus構造体を作成し、Memoryおよびその他のデバイスを統合。
- `bus.rs`  Busが適切なデバイスからデータを読み書きできるように、Busの読み取りおよび書き込みメソッドを実装。
- `cpu.rs` `main.rs`  BusモジュールをNESエミュレータのコードベースに統合。
- `bus.rs`  新しいBusモジュールを使用してNESエミュレータをテストし、正常な機能を確認。
 