### PR TITLE
[Fix #139] Fixed only for implemented instructions

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -2,8 +2,6 @@ use crate::opcodes::{self, Operation::*, OPCODES_MAP};
 use bitflags::bitflags;
 extern crate log;
 use crate::bus::Bus;
-use log::{debug, info};
-use std::collections::BTreeMap;
 
 bitflags! {
     #[derive(Clone,Copy)]
@@ -13,7 +11,7 @@ bitflags! {
         const INTERRUPT_DISABLE = 1 << 2;
         const DECIMAL = 1 << 3;
         const BREAK = 1 << 4;
-        const BREAK_2 = 1 << 5; // 1 << 5 (0b0010_0000) Unused bit
+        const BREAK_2 = 1 << 5;
         const OVERFLOW = 1 << 6;
         const NEGATIVE = 1 << 7;
     }
@@ -345,22 +343,25 @@ impl CPU {
     }
 
     fn asl(&mut self, mode: &AddressingMode) {
-        let value = self.fetch_data(mode);
+        let mut value = self.fetch_data(mode);
 
-        let (shifted_value, _) = value.overflowing_shl(1);
+        if value >> 7 == 1 {
+            self.status.insert(ProcessorStatus::CARRY);
+        } else {
+            self.status.remove(ProcessorStatus::CARRY);
+        }
 
-        self.update_zero_and_negative_flags(value);
-
-        self.status
-            .set(ProcessorStatus::CARRY, (value >> 7) & 1 > 0);
+        value = value << 1;
 
         match mode {
-            AddressingMode::Accumulator => self.accumulator = shifted_value,
+            AddressingMode::Accumulator => self.accumulator = value,
             _ => {
                 let addr = self.get_operand_address(mode);
-                self.mem_write(addr, shifted_value)
+                self.mem_write(addr, value);
             }
         }
+
+        self.update_zero_and_negative_flags(value);
     }
 
     fn lsr(&mut self, mode: &AddressingMode) {
@@ -384,60 +385,85 @@ impl CPU {
     }
 
     fn rol(&mut self, mode: &AddressingMode) {
-        let value = self.fetch_data(mode);
+        let mut value = self.fetch_data(mode);
 
-        let carry_bit = (value >> 7) & 1;
+        let old_carry = self.status.contains(ProcessorStatus::CARRY);
 
-        let (mut rotated_value, _) = value.overflowing_shl(1);
+        if value >> 7 == 1 {
+            self.status.insert(ProcessorStatus::CARRY);
+        } else {
+            self.status.remove(ProcessorStatus::CARRY);
+        }
 
-        rotated_value = rotated_value | carry_bit;
+        value = value << 1;
 
-        self.update_zero_and_negative_flags(value);
-
-        self.status
-            .set(ProcessorStatus::CARRY, (value >> 7) & 1 > 0);
+        if old_carry {
+            value = value | 1;
+        }
 
         match mode {
-            AddressingMode::Accumulator => self.accumulator = rotated_value,
+            AddressingMode::Accumulator => {
+                self.accumulator = value;
+            }
             _ => {
                 let addr = self.get_operand_address(mode);
-                self.mem_write(addr, rotated_value)
+                self.mem_write(addr, value)
             }
         }
+
+        self.update_negative_flags(value);
     }
 
     fn ror(&mut self, mode: &AddressingMode) {
-        let value = self.fetch_data(mode);
+        let mut value = self.fetch_data(mode);
+        let old_carry = self.status.contains(ProcessorStatus::CARRY);
 
-        let carry_bit = value << 7;
-
-        let (shifted_value, _) = value.overflowing_shr(1);
-
-        let rotated_value = shifted_value | carry_bit;
-
-        self.update_zero_and_negative_flags(value);
-
-        self.status
-            .set(ProcessorStatus::CARRY, (value >> 7) & 1 > 0);
+        if value & 1 == 1 {
+            self.status.insert(ProcessorStatus::CARRY);
+        } else {
+            self.status.remove(ProcessorStatus::CARRY);
+        }
+        value = value >> 1;
+        if old_carry {
+            value = value | 0b10000000;
+        }
 
         match mode {
-            AddressingMode::Accumulator => self.accumulator = rotated_value,
+            AddressingMode::Accumulator => {
+                self.accumulator = value;
+            }
             _ => {
                 let addr = self.get_operand_address(mode);
-                self.mem_write(addr, rotated_value)
+                self.mem_write(addr, value)
             }
+        }
+
+        self.update_negative_flags(value);
+    }
+
+    fn update_negative_flags(&mut self, value: u8) {
+        if value & 0b1000_0000 != 0 {
+            self.status.set(ProcessorStatus::NEGATIVE, true);
+        } else {
+            self.status.set(ProcessorStatus::NEGATIVE, false);
         }
     }
 
-    fn branch(&mut self, mode: &AddressingMode, status: &ProcessorStatus, condition: bool) {
-        let addr = self.get_operand_address(mode);
+    fn branch(&mut self, status: &ProcessorStatus, condition: bool) {
+        let jmp = self.mem_read(self.program_counter) as i8;
         if condition {
             if self.status.bits() & status.bits() != 0 {
-                self.program_counter = addr.wrapping_add(1)
+                self.program_counter = self
+                    .program_counter
+                    .wrapping_add(1)
+                    .wrapping_add(jmp as u16);
             }
         } else {
             if self.status.bits() & status.bits() == 0 {
-                self.program_counter = addr.wrapping_add(1)
+                self.program_counter = self
+                    .program_counter
+                    .wrapping_add(1)
+                    .wrapping_add(jmp as u16);
             }
         }
     }
@@ -452,10 +478,10 @@ impl CPU {
             self.status.remove(ProcessorStatus::ZERO)
         }
 
-        let flags = ProcessorStatus::NEGATIVE.bits() | ProcessorStatus::OVERFLOW.bits();
-        let status = (self.status.bits() & !flags) | (value & flags);
         self.status
-            .insert(ProcessorStatus::from_bits_retain(status));
+            .set(ProcessorStatus::NEGATIVE, value & 0b1000_0000 > 0);
+        self.status
+            .set(ProcessorStatus::OVERFLOW, value & 0b0100_0000 > 0);
     }
 
     fn status_bit(&self, reg: &ProcessorStatus) -> u8 {
@@ -490,15 +516,19 @@ impl CPU {
     }
 
     fn php(&mut self) {
-        self.push(self.status.bits());
+        let mut status = self.status.clone();
+        status.insert(ProcessorStatus::BREAK | ProcessorStatus::BREAK_2);
+        self.push(status.bits());
     }
 
     fn plp(&mut self) {
-        self.status = ProcessorStatus::from_bits_truncate(self.pull());
+        self.status = ProcessorStatus::from_bits_truncate(self.pop());
+        self.status.remove(ProcessorStatus::BREAK);
+        self.status.insert(ProcessorStatus::BREAK_2);
     }
 
     fn pla(&mut self) {
-        self.accumulator = self.pull();
+        self.accumulator = self.pop();
         self.update_zero_and_negative_flags(self.accumulator)
     }
 
@@ -515,26 +545,45 @@ impl CPU {
         self.push(lo);
     }
 
-    fn pull(&mut self) -> u8 {
+    fn pop(&mut self) -> u8 {
         self.stack_pointer = self.stack_pointer.wrapping_add(1);
         let addr = self.get_stack_addr();
         let data = self.mem_read(addr);
         data
     }
 
-    fn pull_u16(&mut self) -> u16 {
-        let lo = self.pull() as u16;
-        let hi = self.pull() as u16;
+    fn pop_u16(&mut self) -> u16 {
+        let lo = self.pop() as u16;
+        let hi = self.pop() as u16;
         (hi << 8) | lo
     }
 
     fn get_stack_addr(&self) -> u16 {
-        0x0100 | (self.stack_pointer as u16)
+        0x0100 as u16 + (self.stack_pointer as u16)
     }
 
     fn jmp(&mut self, mode: &AddressingMode) {
-        let addr = self.get_operand_address(mode);
-        self.program_counter = addr;
+        match mode {
+            AddressingMode::Indirect => self.jmp_indirect(),
+            _ => {
+                let addr = self.get_operand_address(mode);
+                self.program_counter = addr;
+            }
+        }
+    }
+
+    fn jmp_indirect(&mut self) {
+        let mem_address = self.mem_read_u16(self.program_counter);
+
+        let indirect_ref = if mem_address & 0x00FF == 0x00FF {
+            let lo = self.mem_read(mem_address);
+            let hi = self.mem_read(mem_address & 0xFF00);
+            (hi as u16) << 8 | (lo as u16)
+        } else {
+            self.mem_read_u16(mem_address)
+        };
+
+        self.program_counter = indirect_ref;
     }
 
     fn jsr(&mut self, mode: &AddressingMode, opcode_len: &u8) {
@@ -547,7 +596,7 @@ impl CPU {
     }
 
     fn rts(&mut self) {
-        let return_addr = self.pull_u16() + 1;
+        let return_addr = self.pop_u16() + 1;
         self.program_counter = return_addr;
     }
 
@@ -561,9 +610,8 @@ impl CPU {
     }
 
     fn rti(&mut self) {
-        // TODO 割り込み処理の実装後に実装
-        // self.plp();
-        // self.program_counter = self.pull_u16();
+        self.plp();
+        self.program_counter = self.pop_u16();
         return;
     }
 
@@ -650,15 +698,15 @@ impl CPU {
                 ROR => self.ror(&opcode.mode),
                 BRK => return,
                 // BRK => self.brk(),
-                // RTI => self.rti(),
-                BCC => self.branch(&opcode.mode, &ProcessorStatus::CARRY, false),
-                BCS => self.branch(&opcode.mode, &ProcessorStatus::CARRY, true),
-                BVC => self.branch(&opcode.mode, &ProcessorStatus::OVERFLOW, false),
-                BVS => self.branch(&opcode.mode, &ProcessorStatus::OVERFLOW, true),
-                BPL => self.branch(&opcode.mode, &ProcessorStatus::NEGATIVE, false),
-                BMI => self.branch(&opcode.mode, &ProcessorStatus::NEGATIVE, true),
-                BNE => self.branch(&opcode.mode, &ProcessorStatus::ZERO, false),
-                BEQ => self.branch(&opcode.mode, &ProcessorStatus::ZERO, true),
+                RTI => self.rti(),
+                BCC => self.branch(&ProcessorStatus::CARRY, false),
+                BCS => self.branch(&ProcessorStatus::CARRY, true),
+                BVC => self.branch(&ProcessorStatus::OVERFLOW, false),
+                BVS => self.branch(&ProcessorStatus::OVERFLOW, true),
+                BPL => self.branch(&ProcessorStatus::NEGATIVE, false),
+                BMI => self.branch(&ProcessorStatus::NEGATIVE, true),
+                BNE => self.branch(&ProcessorStatus::ZERO, false),
+                BEQ => self.branch(&ProcessorStatus::ZERO, true),
                 BIT => self.bit(&opcode.mode),
                 CLC => self.status.remove(ProcessorStatus::CARRY),
                 SEC => self.status.insert(ProcessorStatus::CARRY),

--- a/src/opcodes.rs
+++ b/src/opcodes.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use Operation::*;
 
 #[rustfmt::skip]
-#[derive(Debug,Clone, Copy)]
+#[derive(Debug,Clone, Copy, PartialEq)]
 pub enum Operation {
     ADC,AND,ASL,BCC,BCS,BEQ,BIT,BMI,BNE,BPL,BRK,BVC,BVS,CLC,
     CLD,CLI,CLV,CMP,CPX,CPY,DEC,DEX,DEY,EOR,INC,INX,INY,JMP,


### PR DESCRIPTION
非公式命令が出現するまでnestestを実行することが出来たため
非公式命令の実装後に再度修正する

**変更内容**
- `cpu.rs` nestest.nes実行に伴う修正

**関連issue**
#139