### PR TITLE
[Feat #145] add Unofficial opcodes

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -627,6 +627,47 @@ impl CPU {
     //     }
     // }
 
+    fn rax(&mut self, mode: &AddressingMode) {
+        self.lda(mode);
+        self.tax();
+    }
+
+    fn sax(&mut self, mode: &AddressingMode) {
+        let addr = self.get_operand_address(mode);
+        let value = self.accumulator & self.index_register_x;
+        self.mem_write(addr, value);
+    }
+
+    fn dcp(&mut self, mode: &AddressingMode) {
+        self.dec(mode);
+        self.cmp(mode);
+    }
+
+    fn isb(&mut self, mode: &AddressingMode) {
+        self.inc(mode);
+        self.sbc(mode);
+    }
+
+    fn slo(&mut self, mode: &AddressingMode) {
+        self.asl(mode);
+        self.ora(mode);
+    }
+
+    fn rla(&mut self, mode: &AddressingMode) {
+        self.rol(mode);
+        self.and(mode);
+    }
+
+    fn sre(&mut self, mode: &AddressingMode) {
+        self.lsr(mode);
+        self.eor(mode);
+    }
+
+    fn rra(&mut self, mode: &AddressingMode) {
+        self.ror(mode);
+        self.adc(mode);
+    }
+
     fn fetch_data(&self, mode: &AddressingMode) -> u8 {
         let addr = self.get_operand_address(mode);
         match mode {
@@ -726,7 +767,15 @@ impl CPU {
                 JMP => self.jmp(&opcode.mode),
                 JSR => self.jsr(&opcode.mode, &opcode.len),
                 RTS => self.rts(),
-                _ => todo!(),
+                LAX => self.rax(&opcode.mode),
+                SAX => self.sax(&opcode.mode),
+                DCP => self.dcp(&opcode.mode),
+                ISB => self.isb(&opcode.mode),
+                SLO => self.slo(&opcode.mode),
+                RLA => self.rla(&opcode.mode),
+                SRE => self.sre(&opcode.mode),
+                RRA => self.rra(&opcode.mode),
+                _ => todo!("mnemonic: {:?} ", opcode.mnemonic),
             }
 
             if program_counter_state == self.program_counter {

--- a/src/rom.rs
+++ b/src/rom.rs
@@ -114,14 +114,14 @@ pub mod test {
 
     use super::*;
 
-    struct TestRom {
-        header: Vec<u8>,
-        trainer: Option<Vec<u8>>,
-        pgp_rom: Vec<u8>,
-        chr_rom: Vec<u8>,
+    pub struct TestRom {
+        pub header: Vec<u8>,
+        pub trainer: Option<Vec<u8>>,
+        pub pgp_rom: Vec<u8>,
+        pub chr_rom: Vec<u8>,
     }
 
-    fn create_rom(rom: TestRom) -> Vec<u8> {
+    pub fn create_rom(rom: TestRom) -> Vec<u8> {
         let mut result = Vec::with_capacity(
             rom.header.len()
                 + rom.trainer.as_ref().map_or(0, |t| t.len())
@@ -139,17 +139,20 @@ pub mod test {
         result
     }
 
-    pub fn test_rom() -> Rom {
-        let test_rom = create_rom(TestRom {
+    pub fn test_rom(program: Vec<u8>) -> Rom {
+        let mut test_rom = TestRom {
             header: vec![
                 0x4E, 0x45, 0x53, 0x1A, 0x02, 0x01, 0x31, 00, 00, 00, 00, 00, 00, 00, 00, 00,
             ],
             trainer: None,
             pgp_rom: vec![1; 2 * PRG_ROM_PAGE_SIZE],
             chr_rom: vec![2; 1 * CHR_ROM_PAGE_SIZE],
-        });
+        };
 
-        Rom::new(&test_rom).unwrap()
+        // 先頭要素からプログラムのサイズ分を書き換える
+        test_rom.pgp_rom[0..program.len()].copy_from_slice(&program);
+
+        Rom::new(&create_rom(test_rom)).unwrap()
     }
 
     #[test]


### PR DESCRIPTION
nestest.nesの実行ログ差分が出ている分のUnofficial opcodeを実装
実行ログとの差分は出ない。
残りの分は今後、必要なときに実装

**変更内容**
- `cpu.rs` Unofficial opcodeの実装

関連issue:
#145,#143