### PR TITLE
Implement PPU control register

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod bus;
 pub mod cpu;
 pub mod opcodes;
+pub mod ppu;
 pub mod rom;
 pub mod trace;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 pub mod bus;
 pub mod cpu;
 pub mod opcodes;
+pub mod ppu;
 pub mod rom;
 pub mod trace;
 

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -1,0 +1,2 @@
+pub mod register;
+use register::control::ControlRegister;

--- a/src/ppu/register.rs
+++ b/src/ppu/register.rs
@@ -1,0 +1,1 @@
+pub mod control;

--- a/src/ppu/register/control.rs
+++ b/src/ppu/register/control.rs
@@ -1,0 +1,72 @@
+use bitflags::bitflags;
+
+bitflags! {
+
+//    7  bit  0
+//    ---- ----
+//    VPHB SINN
+//    |||| ||||
+//    |||| ||++- Base nametable address
+//    |||| ||    (0 = $2000; 1 = $2400; 2 = $2800; 3 = $2C00)
+//    |||| |+--- VRAM address increment per CPU read/write of PPUDATA
+//    |||| |     (0: add 1, going across; 1: add 32, going down)
+//    |||| +---- Sprite pattern table address for 8x8 sprites
+//    ||||       (0: $0000; 1: $1000; ignored in 8x16 mode)
+//    |||+------ Background pattern table address (0: $0000; 1: $1000)
+//    ||+------- Sprite size (0: 8x8 pixels; 1: 8x16 pixels)
+//    |+-------- PPU master/slave select
+//    |          (0: read backdrop from EXT pins; 1: output color on EXT pins)
+//    +--------- Generate an NMI at the start of the
+//               vertical blanking interval (0: off; 1: on)
+
+    #[derive(Debug,PartialEq)]
+    pub struct ControlRegister: u8 {
+        const NAMETABLE1             = 1;
+        const NAMETABLE2             = 1 << 1;
+        const VRAM_ADD_INCREMENT     = 1 << 2;
+        const SPRITE_PATTERN_ADDR    = 1 << 3;
+        const BACKGROUD_PATTERN_ADDR = 1 << 4;
+        const SPRITE_SIZE            = 1 << 5;
+        const MASTER_SLAVE_SELECT    = 1 << 6;
+        const GENERATE_NMI           = 1 << 7;
+    }
+}
+
+impl ControlRegister {
+    pub fn new() -> Self {
+        ControlRegister::from_bits_truncate(0)
+    }
+
+    pub fn vram_addr_increment(&self) -> u8 {
+        if !self.contains(ControlRegister::VRAM_ADD_INCREMENT) {
+            1
+        } else {
+            32
+        }
+    }
+
+    pub fn update(&mut self, data: u8) {
+        *self = ControlRegister::from_bits_truncate(data);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_vram_addr_increment() {
+        let control = ControlRegister::from_bits_truncate(0b0000_0100);
+        assert_eq!(control.vram_addr_increment(), 32);
+
+        let control = ControlRegister::from_bits_truncate(0b0000_0000);
+        assert_eq!(control.vram_addr_increment(), 1);
+    }
+
+    #[test]
+    fn test_update() {
+        let mut control = ControlRegister::new();
+        control.update(0b1000_0000);
+        assert_eq!(control, ControlRegister::GENERATE_NMI);
+    }
+}


### PR DESCRIPTION
This pull request adds the implementation of the PPU control register, which allows for setting various PPU parameters such as the nametable address, VRAM address increment, sprite pattern table address, background pattern table address, sprite size, PPU master/slave select, and NMI generation. The `ControlRegister` struct is defined in the `register` module, and includes methods for updating the register and retrieving the VRAM address increment value.